### PR TITLE
Add student device report

### DIFF
--- a/docs/STUDENT_DEVICE_REPORT_TODO.md
+++ b/docs/STUDENT_DEVICE_REPORT_TODO.md
@@ -1,0 +1,41 @@
+# Student Device Report TODO
+
+## Research Notes
+
+- Existing Google Admin access is already wrapped by `src/functions/googleAdmin.ts`.
+  - `mode=google&user=email` returns ChromeOS devices associated with a user.
+  - `mode=google&serial=serial` returns one ChromeOS device by serial.
+- Current reports already fetch inventory/student-loan rows from Airtable and can enrich assets with Google Admin data.
+- Student lookup is currently name-search oriented and capped at 100 records, so this feature needs a report-oriented student query that can return all students for a YOG/status or uploaded email list.
+- Inventory can already fetch all Chromebooks with current student/staff ownership fields, which is enough to classify each Google-last-used machine as normal, signed out to someone else, checked in, or missing from inventory.
+
+## Implementation Slices
+
+1. Add report-mode student query.
+   - Filter by YOG.
+   - Filter by `Active`, `Inactive`, or all.
+   - Filter by uploaded email list.
+   - Return enough fields to render students with zero machine history.
+
+2. Add data aggregation layer.
+   - Fetch selected students.
+   - Fetch all Chromebook inventory once and index by serial.
+   - Fetch Google Admin devices for each selected student with capped concurrency.
+   - Build per-student rows with current loans, last-used machines, counts, and status classification.
+
+3. Add UI under Reports.
+   - New tab: Student Device Report.
+   - Input mode for class year or pasted/uploaded email list.
+   - Student status selector.
+   - Progress while Google lookups run.
+   - Sort by current loans, last-used machines, and problem count.
+   - Show status icons/colors for normal, signed out to someone else, checked in, and unknown inventory.
+
+4. Export.
+   - Add CSV export for flattened machine rows.
+   - Include zero-machine students in export.
+
+5. Follow-up questions.
+   - Should uploaded lists be treated as an exact email allow-list plus status filter, or should status be ignored for explicit lists?
+   - Should old Google Admin activity be considered stale/problematic at a specific threshold, or only informational?
+   - Should staff-signed-out machines be a separate warning category from student-signed-out-to-other?

--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -180,6 +180,10 @@ export async function getNonLoanedChromebooks() {
   return await fetchReport({ chromebookOnly: true, notLoaned: true });
 }
 
+export async function getAllChromebooks() {
+  return await fetchReport({ chromebookOnly: true });
+}
+
 // Update asset function
 export async function updateAsset(id: string, fields: any) {
   try {

--- a/src/data/studentDeviceReport.ts
+++ b/src/data/studentDeviceReport.ts
@@ -106,7 +106,7 @@ function dateKey(value: string | null | undefined) {
 
 function checkedInClassification(
   lastUsed: string | null,
-  latestHistory: SignoutHistoryEntry | null
+  latestHistory: SignoutHistoryEntry | null,
 ): Pick<
   StudentDeviceReportMachine,
   "status" | "statusLabel" | "currentOwner" | "checkoutTime" | "checkInTime"
@@ -169,7 +169,7 @@ function classifyMachine(
   student: Student,
   asset: Asset | null,
   lastUsed: string | null,
-  latestHistory: SignoutHistoryEntry | null
+  latestHistory: SignoutHistoryEntry | null,
 ): Pick<
   StudentDeviceReportMachine,
   "status" | "statusLabel" | "currentOwner" | "checkoutTime" | "checkInTime"
@@ -185,7 +185,9 @@ function classifyMachine(
   }
 
   const studentEmail = student.Email.toLowerCase();
-  const currentStudentEmail = normalizeEmail(asset["Email (from Student (Current))"]);
+  const currentStudentEmail = normalizeEmail(
+    asset["Email (from Student (Current))"],
+  );
   const currentStaffEmail = normalizeEmail(asset["Staff Email"]);
 
   if (currentStudentEmail) {
@@ -194,7 +196,8 @@ function classifyMachine(
         status: "normal",
         statusLabel: "Signed out to this student",
         currentOwner: currentStudentEmail,
-        checkoutTime: latestHistory?.Status === "Out" ? latestHistory.Time : null,
+        checkoutTime:
+          latestHistory?.Status === "Out" ? latestHistory.Time : null,
         checkInTime: null,
       };
     }
@@ -237,7 +240,9 @@ function indexAssets(assets: Asset[]) {
       bySerial.set(serial, asset);
     }
 
-    const studentEmail = normalizeEmail(asset["Email (from Student (Current))"]);
+    const studentEmail = normalizeEmail(
+      asset["Email (from Student (Current))"],
+    );
     if (studentEmail) {
       const loans = loansByStudentEmail.get(studentEmail) || [];
       loans.push(asset);
@@ -268,14 +273,14 @@ function indexLatestHistory(entries: SignoutHistoryEntry[]) {
 
 function isProblemMachine(machine: StudentDeviceReportMachine) {
   return !["normal", "checkedInAfterUse", "checkedInSameDay"].includes(
-    machine.status
+    machine.status,
   );
 }
 
 async function runWithConcurrency<T>(
   items: T[],
   limit: number,
-  worker: (item: T, index: number) => Promise<void>
+  worker: (item: T, index: number) => Promise<void>,
 ) {
   let nextIndex = 0;
   const workers = Array.from(
@@ -286,13 +291,13 @@ async function runWithConcurrency<T>(
         nextIndex += 1;
         await worker(items[index], index);
       }
-    }
+    },
   );
   await Promise.all(workers);
 }
 
 export function flattenStudentDeviceReport(
-  rows: StudentDeviceReportRow[]
+  rows: StudentDeviceReportRow[],
 ): Record<string, any>[] {
   const exportedRows: Record<string, any>[] = [];
 
@@ -330,7 +335,7 @@ export function flattenStudentDeviceReport(
         Serial: machine.serial,
         "Last Activity Date": machine.lastUsed || "",
         "Last Activity Duration": formatDuration(
-          getLastActiveTime(machine.googleData)
+          getLastActiveTime(machine.googleData),
         ),
         "Recent Users": recentUserEmails(machine.googleData).join(";"),
         "Checkout Status": machine.currentOwner
@@ -366,7 +371,7 @@ export async function buildStudentDeviceReport({
   const assets = (rawAssets || []).map(normalizeAssetRecord);
   const { bySerial, loansByStudentEmail } = indexAssets(assets);
   const latestHistoryByAssetTag = indexLatestHistory(
-    await lookupSignoutHistory({ isLatest: true })
+    await lookupSignoutHistory({ isLatest: true }),
   );
   const rows = new Array<StudentDeviceReportRow>(students.length);
   let completed = 0;
@@ -375,24 +380,34 @@ export async function buildStudentDeviceReport({
     students,
     MAX_CONCURRENT_GOOGLE_LOOKUPS,
     async (student, index) => {
-      const currentLoans =
-        loansByStudentEmail.get(student.Email.toLowerCase()) || [];
+      const studentEmail = normalizeEmail(student.Email);
+      const currentLoans = loansByStudentEmail.get(studentEmail) || [];
       let googleDevices: ChromebookInfo[] = [];
 
-      try {
-        googleDevices = (await getDevicesForUser(student)) || [];
-      } catch (error) {
-        logger.logError("Student device report Google lookup failed:", {
-          student,
-          error,
-        });
+      if (studentEmail) {
+        try {
+          googleDevices = (await getDevicesForUser(student)) || [];
+        } catch (error) {
+          logger.logError("Student device report Google lookup failed:", {
+            student,
+            error,
+          });
+        }
+      } else {
+        logger.logRegular(
+          "Student device report: missing student email; skipping Google lookup",
+          {
+            studentId: student._id,
+            studentName: student.Name,
+          },
+        );
       }
 
       const machines = googleDevices
         .filter(
           (device) =>
-            device.recentUsers?.[0]?.email?.toLowerCase() ===
-            student.Email.toLowerCase()
+            studentEmail &&
+            device.recentUsers?.[0]?.email?.toLowerCase() === studentEmail,
         )
         .map((device) => {
           const serial = normalizeSerial(device.serialNumber);
@@ -406,7 +421,7 @@ export async function buildStudentDeviceReport({
             student,
             asset,
             lastUsed,
-            latestHistory
+            latestHistory,
           );
           return {
             serial: device.serialNumber,
@@ -437,7 +452,7 @@ export async function buildStudentDeviceReport({
 
       completed += 1;
       onProgress?.({ completed, total: students.length, student });
-    }
+    },
   );
 
   return rows;

--- a/src/data/studentDeviceReport.ts
+++ b/src/data/studentDeviceReport.ts
@@ -1,0 +1,444 @@
+import type { Asset } from "./inventory";
+import { getAllChromebooks } from "./inventory";
+import { getDevicesForUser, type ChromebookInfo } from "./google";
+import type { Student } from "./students";
+import { fetchStudentsForReport } from "./students";
+import {
+  lookupSignoutHistory,
+  type SignoutHistoryEntry,
+} from "./signoutHistory";
+import { logger } from "@utils/log";
+
+export type StudentDeviceMachineStatus =
+  | "normal"
+  | "signedOutToOther"
+  | "signedOutToStaff"
+  | "checkedInAfterUse"
+  | "checkedInSameDay"
+  | "checkedInAfterGoogleUse"
+  | "checkedInUnknown"
+  | "unknown";
+
+export type StudentDeviceReportMachine = {
+  serial: string;
+  assetTag: string;
+  model: string;
+  lastUsed: string | null;
+  lastUser: string;
+  status: StudentDeviceMachineStatus;
+  statusLabel: string;
+  currentOwner: string;
+  checkoutTime: string | null;
+  checkInTime: string | null;
+  asset: Asset | null;
+  googleData: ChromebookInfo;
+  latestHistory: SignoutHistoryEntry | null;
+};
+
+export type StudentDeviceReportRow = {
+  student: Student;
+  currentLoans: Asset[];
+  machines: StudentDeviceReportMachine[];
+  currentLoanCount: number;
+  lastUsedMachineCount: number;
+  problemCount: number;
+};
+
+export type StudentDeviceReportProgress = {
+  completed: number;
+  total: number;
+  student?: Student;
+};
+
+const MAX_CONCURRENT_GOOGLE_LOOKUPS = 6;
+
+function firstValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value[0] ? String(value[0]) : "";
+  }
+  return value ? String(value) : "";
+}
+
+function normalizeEmail(value: unknown): string {
+  return firstValue(value).trim().toLowerCase();
+}
+
+function normalizeSerial(value: unknown): string {
+  return firstValue(value).trim().toLowerCase();
+}
+
+function getLastUsed(device: ChromebookInfo) {
+  const ranges = device.activeTimeRanges || [];
+  return ranges.length ? ranges[ranges.length - 1].date : null;
+}
+
+function getLastActiveTime(device: ChromebookInfo) {
+  const ranges = device.activeTimeRanges || [];
+  return ranges.length ? ranges[ranges.length - 1].activeTime : null;
+}
+
+function formatDuration(ms: number | null) {
+  if (!ms && ms !== 0) return "";
+  const totalMinutes = Math.round(ms / 1000 / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours) return `${hours}:${String(minutes).padStart(2, "0")}`;
+  return `${minutes} min`;
+}
+
+function recentUserEmails(device: ChromebookInfo) {
+  return (device.recentUsers || []).map((user) => user.email).filter(Boolean);
+}
+
+function getAssetTag(asset: Asset | null, device: ChromebookInfo) {
+  return asset?.["Asset Tag"] || device.annotatedUser || "(unknown asset)";
+}
+
+function dateKey(value: string | null | undefined) {
+  if (!value) return "";
+  if (/^\d{4}-\d{2}-\d{2}/.test(value)) {
+    return value.slice(0, 10);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toISOString().slice(0, 10);
+}
+
+function checkedInClassification(
+  lastUsed: string | null,
+  latestHistory: SignoutHistoryEntry | null
+): Pick<
+  StudentDeviceReportMachine,
+  "status" | "statusLabel" | "currentOwner" | "checkoutTime" | "checkInTime"
+> {
+  if (latestHistory?.Status !== "Returned") {
+    return {
+      status: "checkedInUnknown",
+      statusLabel: latestHistory?.Status
+        ? `No current owner; latest status is ${latestHistory.Status}`
+        : "Checked in; no check-in date found",
+      currentOwner: "",
+      checkoutTime: null,
+      checkInTime: latestHistory?.Time || null,
+    };
+  }
+
+  const lastUsedDate = dateKey(lastUsed);
+  const checkInDate = dateKey(latestHistory.Time);
+
+  if (!lastUsedDate || !checkInDate) {
+    return {
+      status: "checkedInUnknown",
+      statusLabel: "Checked in; date comparison unavailable",
+      currentOwner: "",
+      checkoutTime: null,
+      checkInTime: latestHistory.Time || null,
+    };
+  }
+
+  if (lastUsedDate < checkInDate) {
+    return {
+      status: "checkedInAfterUse",
+      statusLabel: "Checked in after Google activity",
+      currentOwner: "",
+      checkoutTime: null,
+      checkInTime: latestHistory.Time,
+    };
+  }
+
+  if (lastUsedDate > checkInDate) {
+    return {
+      status: "checkedInAfterGoogleUse",
+      statusLabel: "Google activity after check-in",
+      currentOwner: "",
+      checkoutTime: null,
+      checkInTime: latestHistory.Time,
+    };
+  }
+
+  return {
+    status: "checkedInSameDay",
+    statusLabel: "Checked in same day as Google activity",
+    currentOwner: "",
+    checkoutTime: null,
+    checkInTime: latestHistory.Time,
+  };
+}
+
+function classifyMachine(
+  student: Student,
+  asset: Asset | null,
+  lastUsed: string | null,
+  latestHistory: SignoutHistoryEntry | null
+): Pick<
+  StudentDeviceReportMachine,
+  "status" | "statusLabel" | "currentOwner" | "checkoutTime" | "checkInTime"
+> {
+  if (!asset) {
+    return {
+      status: "unknown",
+      statusLabel: "Not found in inventory",
+      currentOwner: "",
+      checkoutTime: null,
+      checkInTime: null,
+    };
+  }
+
+  const studentEmail = student.Email.toLowerCase();
+  const currentStudentEmail = normalizeEmail(asset["Email (from Student (Current))"]);
+  const currentStaffEmail = normalizeEmail(asset["Staff Email"]);
+
+  if (currentStudentEmail) {
+    if (currentStudentEmail === studentEmail) {
+      return {
+        status: "normal",
+        statusLabel: "Signed out to this student",
+        currentOwner: currentStudentEmail,
+        checkoutTime: latestHistory?.Status === "Out" ? latestHistory.Time : null,
+        checkInTime: null,
+      };
+    }
+    return {
+      status: "signedOutToOther",
+      statusLabel: "Signed out to another student",
+      currentOwner: currentStudentEmail,
+      checkoutTime: latestHistory?.Status === "Out" ? latestHistory.Time : null,
+      checkInTime: null,
+    };
+  }
+
+  if (currentStaffEmail) {
+    return {
+      status: "signedOutToStaff",
+      statusLabel: "Signed out to staff",
+      currentOwner: currentStaffEmail,
+      checkoutTime: latestHistory?.Status === "Out" ? latestHistory.Time : null,
+      checkInTime: null,
+    };
+  }
+
+  return checkedInClassification(lastUsed, latestHistory);
+}
+
+function normalizeAssetRecord(record): Asset {
+  return {
+    ...record.fields,
+    _id: record.id,
+  };
+}
+
+function indexAssets(assets: Asset[]) {
+  const bySerial = new Map<string, Asset>();
+  const loansByStudentEmail = new Map<string, Asset[]>();
+
+  for (const asset of assets) {
+    const serial = normalizeSerial(asset.Serial);
+    if (serial) {
+      bySerial.set(serial, asset);
+    }
+
+    const studentEmail = normalizeEmail(asset["Email (from Student (Current))"]);
+    if (studentEmail) {
+      const loans = loansByStudentEmail.get(studentEmail) || [];
+      loans.push(asset);
+      loansByStudentEmail.set(studentEmail, loans);
+    }
+  }
+
+  return { bySerial, loansByStudentEmail };
+}
+
+function indexLatestHistory(entries: SignoutHistoryEntry[]) {
+  const byAssetTag = new Map<string, SignoutHistoryEntry>();
+
+  for (const entry of entries) {
+    const assetTag = firstValue(entry["Asset Tag (from Asset)"]);
+    if (!assetTag) continue;
+
+    const existing = byAssetTag.get(assetTag);
+    const existingTime = existing?.Time ? new Date(existing.Time).getTime() : 0;
+    const entryTime = entry.Time ? new Date(entry.Time).getTime() : 0;
+    if (!existing || entryTime > existingTime) {
+      byAssetTag.set(assetTag, entry);
+    }
+  }
+
+  return byAssetTag;
+}
+
+function isProblemMachine(machine: StudentDeviceReportMachine) {
+  return !["normal", "checkedInAfterUse", "checkedInSameDay"].includes(
+    machine.status
+  );
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<void>
+) {
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        await worker(items[index], index);
+      }
+    }
+  );
+  await Promise.all(workers);
+}
+
+export function flattenStudentDeviceReport(
+  rows: StudentDeviceReportRow[]
+): Record<string, any>[] {
+  const exportedRows: Record<string, any>[] = [];
+
+  for (const row of rows) {
+    if (!row.machines.length) {
+      exportedRows.push({
+        Student: row.student.Email,
+        Name: row.student.Name,
+        YOG: row.student.YOG,
+        Status: row.student.Status,
+        "Machine Number": "",
+        "Machine Count": 0,
+        "Asset Tag": "",
+        Serial: "",
+        "Last Activity Date": "",
+        "Last Activity Duration": "",
+        "Recent Users": "",
+        "Checkout Status": "",
+        "Checkout Time": "",
+        "Check-In Time": "",
+        Summary: "No Google last-used machines",
+      });
+      continue;
+    }
+
+    row.machines.forEach((machine, index) => {
+      exportedRows.push({
+        Student: row.student.Email,
+        Name: row.student.Name,
+        YOG: row.student.YOG,
+        Status: row.student.Status,
+        "Machine Number": index + 1,
+        "Machine Count": row.lastUsedMachineCount,
+        "Asset Tag": machine.assetTag,
+        Serial: machine.serial,
+        "Last Activity Date": machine.lastUsed || "",
+        "Last Activity Duration": formatDuration(
+          getLastActiveTime(machine.googleData)
+        ),
+        "Recent Users": recentUserEmails(machine.googleData).join(";"),
+        "Checkout Status": machine.currentOwner
+          ? `Signed out to ${machine.currentOwner}`
+          : machine.checkInTime
+            ? `Checked in ${machine.checkInTime}`
+            : machine.status === "unknown"
+              ? "Not found in inventory"
+              : "Checked in; no check-in date found",
+        "Checkout Time": machine.checkoutTime || "",
+        "Check-In Time": machine.checkInTime || "",
+        Summary: machine.statusLabel,
+      });
+    });
+  }
+
+  return exportedRows;
+}
+
+export async function buildStudentDeviceReport({
+  yog,
+  status,
+  emails,
+  onProgress,
+}: {
+  yog?: string;
+  status?: string;
+  emails?: string[];
+  onProgress?: (progress: StudentDeviceReportProgress) => void;
+} = {}): Promise<StudentDeviceReportRow[]> {
+  const students = await fetchStudentsForReport({ yog, status, emails });
+  const rawAssets = await getAllChromebooks();
+  const assets = (rawAssets || []).map(normalizeAssetRecord);
+  const { bySerial, loansByStudentEmail } = indexAssets(assets);
+  const latestHistoryByAssetTag = indexLatestHistory(
+    await lookupSignoutHistory({ isLatest: true })
+  );
+  const rows = new Array<StudentDeviceReportRow>(students.length);
+  let completed = 0;
+
+  await runWithConcurrency(
+    students,
+    MAX_CONCURRENT_GOOGLE_LOOKUPS,
+    async (student, index) => {
+      const currentLoans =
+        loansByStudentEmail.get(student.Email.toLowerCase()) || [];
+      let googleDevices: ChromebookInfo[] = [];
+
+      try {
+        googleDevices = (await getDevicesForUser(student)) || [];
+      } catch (error) {
+        logger.logError("Student device report Google lookup failed:", {
+          student,
+          error,
+        });
+      }
+
+      const machines = googleDevices
+        .filter(
+          (device) =>
+            device.recentUsers?.[0]?.email?.toLowerCase() ===
+            student.Email.toLowerCase()
+        )
+        .map((device) => {
+          const serial = normalizeSerial(device.serialNumber);
+          const asset = bySerial.get(serial) || null;
+          const assetTag = getAssetTag(asset, device);
+          const lastUsed = getLastUsed(device);
+          const latestHistory = asset
+            ? latestHistoryByAssetTag.get(asset["Asset Tag"]) || null
+            : null;
+          const classification = classifyMachine(
+            student,
+            asset,
+            lastUsed,
+            latestHistory
+          );
+          return {
+            serial: device.serialNumber,
+            assetTag,
+            model: asset?.Model || device.model || "",
+            lastUsed,
+            lastUser: device.recentUsers?.[0]?.email || "",
+            asset,
+            googleData: device,
+            latestHistory,
+            ...classification,
+          };
+        })
+        .sort((a, b) => {
+          const aTime = a.lastUsed ? new Date(a.lastUsed).getTime() : 0;
+          const bTime = b.lastUsed ? new Date(b.lastUsed).getTime() : 0;
+          return bTime - aTime;
+        });
+
+      rows[index] = {
+        student,
+        currentLoans,
+        machines,
+        currentLoanCount: currentLoans.length,
+        lastUsedMachineCount: machines.length,
+        problemCount: machines.filter(isProblemMachine).length,
+      };
+
+      completed += 1;
+      onProgress?.({ completed, total: students.length, student });
+    }
+  );
+
+  return rows;
+}

--- a/src/data/students.ts
+++ b/src/data/students.ts
@@ -40,6 +40,63 @@ export async function searchForStudent(name) {
   return json;
 }
 
+export async function fetchStudentsForReport({
+  yog,
+  status,
+  emails,
+}: {
+  yog?: string;
+  status?: string;
+  emails?: string[];
+} = {}) {
+  let params: any = { mode: "student", report: "true" };
+  if (yog) {
+    params.yog = yog;
+  }
+  if (status) {
+    params.status = status;
+  }
+  if (emails?.length) {
+    params.emails = emails.join(",");
+  }
+
+  let response = await fetch(
+    "/.netlify/functions/index?" + new URLSearchParams(params)
+  );
+  if (!response.ok) {
+    throw new Error(`Student report lookup failed: ${response.status}`);
+  }
+  let responseText = await response.text();
+  let json;
+  try {
+    json = JSON.parse(responseText);
+  } catch (error) {
+    if (responseText.trim().startsWith("<!DOCTYPE")) {
+      throw new Error(
+        "Student report lookup returned the app HTML instead of function JSON. Open the app through Netlify Dev, for example http://localhost:8888 or http://localhost:8890, not the frontend-only Svelte port."
+      );
+    }
+    throw new Error("Student report lookup returned invalid JSON.");
+  }
+  logger.logVerbose("Got student report data:", json);
+  studentsStore.update(($studentsStore) => {
+    for (let result of json) {
+      const student = {
+        ...result.fields,
+        Tickets: result.fields.Tickets || [],
+        _id: result.id,
+      };
+      $studentsStore[result.fields.LASID] = student;
+    }
+    return $studentsStore;
+  });
+  return json.map((result) => ({
+    ...result.fields,
+    Tickets: result.fields.Tickets || [],
+    _id: result.id,
+  })) as Student[];
+}
+
 export function getStudent(name: string): Student {
   for (let item of Object.values(get(studentsStore)) as Student[]) {
     if (item.Name == name) {

--- a/src/functions/students.ts
+++ b/src/functions/students.ts
@@ -2,7 +2,12 @@ import type { APIGatewayEvent, Context } from "aws-lambda";
 import { studentsBase } from "./Airtable";
 
 export async function handler(event: APIGatewayEvent, context: Context) {
-  const { name } = event.queryStringParameters;
+  const { name, report, yog, status, emails } = event.queryStringParameters || {};
+
+  if (report === "true") {
+    return getStudentsForReport({ yog, status, emails });
+  }
+
   let query = studentsBase.select({
     maxRecords: 100,
     filterByFormula: `Search("${name.toLowerCase()}",LOWER({Name}))`,
@@ -24,5 +29,97 @@ export async function handler(event: APIGatewayEvent, context: Context) {
   return {
     statusCode: 200,
     body: JSON.stringify(result),
+  };
+}
+
+function airtableString(value: string) {
+  return String(value || "").replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function parseEmails(value?: string) {
+  return (value || "")
+    .split(/[,\n\r\t ;]+/)
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+async function getStudentsForReport({
+  yog,
+  status,
+  emails,
+}: {
+  yog?: string;
+  status?: string;
+  emails?: string;
+}) {
+  let filters = [];
+  const requestedEmails = parseEmails(emails);
+
+  if (yog) {
+    filters.push(`{YOG}="${airtableString(yog)}"`);
+  }
+  if (status) {
+    filters.push(`{Status}="${airtableString(status)}"`);
+  }
+  if (requestedEmails.length) {
+    filters.push(
+      `OR(${requestedEmails
+        .map((email) => `LOWER({Email})="${airtableString(email)}"`)
+        .join(",")})`
+    );
+  }
+
+  const filterByFormula = filters.length ? `AND(${filters.join(",")})` : "";
+  let allRecords = [];
+  let totalRecordsFetched = 0;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      studentsBase
+        .select({
+          filterByFormula,
+          fields: [
+            "LASID",
+            "Name",
+            "Email",
+            "YOG",
+            "Advisor",
+            "Notes",
+            "Status",
+            "Tickets",
+            "Ticket Numbers",
+          ],
+        })
+        .eachPage(
+          (records, fetchNextPage) => {
+            allRecords = allRecords.concat(records);
+            totalRecordsFetched += records.length;
+            if (totalRecordsFetched > 2000) {
+              reject(new Error("TOO_MANY_RECORDS"));
+              return;
+            }
+            fetchNextPage();
+          },
+          (err) => {
+            if (err) reject(err);
+            else resolve();
+          }
+        );
+    });
+  } catch (err) {
+    if (err.message === "TOO_MANY_RECORDS") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: "Too many students requested. Please refine your query.",
+        }),
+      };
+    }
+    throw err;
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(allRecords),
   };
 }

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -3,6 +3,7 @@
   import { l } from "@utils/util";
   export let asset: Asset | null = null;
   export let showOwner: boolean = false;
+  export let openInNewTab: boolean = false;
   $: assetTag = (asset && asset["Asset Tag"]) || "";
 </script>
 
@@ -16,9 +17,15 @@
       class:w3-red={/^A[0-9][0-9][0-9][0-9]/.test(assetTag)}
       class:w3-black={/^[0-9][0-9][0-9]$/.test(assetTag)}
     >
-      <a href={`/asset/${assetTag}`} on:click={l(`/asset/${assetTag}`)}
-        >{assetTag}</a
-      >
+      {#if openInNewTab}
+        <a href={`/asset/${assetTag}`} target="_blank" rel="noreferrer"
+          >{assetTag}</a
+        >
+      {:else}
+        <a href={`/asset/${assetTag}`} on:click={l(`/asset/${assetTag}`)}
+          >{assetTag}</a
+        >
+      {/if}
     </div>
     <div class="column">
       <div class="model limit w3-small">

--- a/src/ui/reports/DataExporter.svelte
+++ b/src/ui/reports/DataExporter.svelte
@@ -6,22 +6,29 @@
   function exportToCSV() {
     if (!items.length) return;
 
+    function csvCell(value: any) {
+      if (Array.isArray(value)) {
+        value = value.join(";");
+      }
+      const text = value !== undefined && value !== null ? String(value) : "";
+      if (/[",\n\r]/.test(text)) {
+        return `"${text.replace(/"/g, '""')}"`;
+      }
+      return text;
+    }
+
     // Build CSV content
     const csvHeaders = headers.length ? headers : Object.keys(items[0]);
     const csvRows = items.map(
       (item) =>
         csvHeaders
-          .map((header) => {
-            const value = item[header];
-            if (Array.isArray(value)) {
-              return value.join(";"); // Join array values with ";"
-            }
-            return value !== undefined ? value : ""; // Handle undefined values
-          })
+          .map((header) => csvCell(item[header]))
           .join(",") // Join fields with ","
     );
 
-    const csvContent = [csvHeaders.join(","), ...csvRows].join("\n");
+    const csvContent = [csvHeaders.map(csvCell).join(","), ...csvRows].join(
+      "\n"
+    );
 
     // Create a downloadable link
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onDestroy, onMount, tick } from "svelte";
   import { logger } from "@utils/log";
   import AssetDisplay from "@assets/AssetDisplay.svelte";
   import DataExporter from "./DataExporter.svelte";
@@ -15,6 +16,75 @@
   export let headers = [];
 
   let sortedData = [];
+  let tableScrollEl;
+  let topScrollEl;
+  let reportTableEl;
+  let topScrollWidth = 0;
+  let showTopScroll = false;
+  let resizeObserver;
+
+  function syncScrollMetrics() {
+    if (!tableScrollEl || !reportTableEl) return;
+    topScrollWidth = reportTableEl.scrollWidth;
+    showTopScroll = reportTableEl.scrollWidth > tableScrollEl.clientWidth + 1;
+    if (topScrollEl && topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
+      topScrollEl.scrollLeft = tableScrollEl.scrollLeft;
+    }
+  }
+
+  function handleTopScroll() {
+    if (!tableScrollEl || !topScrollEl) return;
+    if (tableScrollEl.scrollLeft !== topScrollEl.scrollLeft) {
+      tableScrollEl.scrollLeft = topScrollEl.scrollLeft;
+    }
+  }
+
+  function handleTableScroll() {
+    if (!tableScrollEl || !topScrollEl) return;
+    if (topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
+      topScrollEl.scrollLeft = tableScrollEl.scrollLeft;
+    }
+  }
+
+  let syncPending = false;
+  async function scheduleSyncMetrics() {
+    if (syncPending) return;
+    syncPending = true;
+    await tick();
+    syncPending = false;
+    syncScrollMetrics();
+  }
+
+  $: filteredData.length,
+    columns.length,
+    headers.length,
+    haveGoogleData,
+    scheduleSyncMetrics();
+
+  onMount(() => {
+    const onResize = () => syncScrollMetrics();
+    window.addEventListener("resize", onResize);
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => syncScrollMetrics());
+      if (reportTableEl) {
+        resizeObserver.observe(reportTableEl);
+      }
+    }
+    scheduleSyncMetrics();
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  });
+
+  onDestroy(() => {
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    }
+  });
 
   function isStale(lastUsed) {
     const thirtyDaysAgo = new Date();
@@ -504,127 +574,149 @@
     </div>
   {/if}
 
-  <table class="w3-table w3-bordered w3-striped">
-    <thead>
-      <tr>
-        <th>
-          <input
-            type="checkbox"
-            checked={selectedAssetTags.size === filteredData.length &&
-              filteredData.length > 0}
-            indeterminate={selectedAssetTags.size > 0 &&
-              selectedAssetTags.size < filteredData.length}
-            on:change={toggleSelectAll}
-          />
-        </th>
-        {#each headers as header, i}
-          <th
-            on:click={() => {
-              const colProp = columns[i];
-              if (sortColumn === colProp) {
-                sortDirection = sortDirection === "asc" ? "desc" : "asc";
-              } else {
-                sortColumn = colProp;
-                sortDirection = "asc";
-              }
-            }}
-          >
-            {header}
-          </th>
-        {/each}
-        {#if haveGoogleData}
-          <th
-            on:click={() => {
-              if (sortColumn === "lastUserMatch") {
-                sortDirection = sortDirection === "asc" ? "desc" : "asc";
-              } else {
-                sortColumn = "lastUserMatch";
-                sortDirection = "asc";
-              }
-            }}
-            style="cursor:pointer"
-          >
-            Last User?
-          </th>
-          <th
-            on:click={() => {
-              if (sortColumn === "lastUsed") {
-                sortDirection = sortDirection === "asc" ? "desc" : "asc";
-              } else {
-                sortColumn = "lastUsed";
-                sortDirection = "asc";
-              }
-            }}
-            style="cursor:pointer"
-          >
-            Last Used
-          </th>
-        {/if}
-      </tr>
-    </thead>
-    <tbody>
-      {#each filteredData as row (row.Serial)}
-        <tr
-          class:highlight-stale={haveGoogleData && isStale(row.lastUsed)}
-          class:highlight-wrong-user={haveGoogleData && !row.lastUserMatch}
-        >
-          <td>
+  {#if showTopScroll}
+    <div
+      class="top-scrollbar"
+      bind:this={topScrollEl}
+      on:scroll={handleTopScroll}
+    >
+      <div
+        class="top-scrollbar-content"
+        style={`width: ${topScrollWidth}px;`}
+      ></div>
+    </div>
+  {/if}
+  <div
+    class="report-table-scroll"
+    bind:this={tableScrollEl}
+    on:scroll={handleTableScroll}
+  >
+    <table
+      bind:this={reportTableEl}
+      class="w3-table w3-bordered w3-striped report-table-grid"
+    >
+      <thead>
+        <tr>
+          <th>
             <input
               type="checkbox"
-              checked={selectedAssetTags.has(row["Asset Tag"])}
-              on:change={() => toggleSelectRow(row)}
+              checked={selectedAssetTags.size === filteredData.length &&
+                filteredData.length > 0}
+              indeterminate={selectedAssetTags.size > 0 &&
+                selectedAssetTags.size < filteredData.length}
+              on:change={toggleSelectAll}
             />
-          </td>
-          {#each columns as column, i (i)}
-            <td>
-              {#if column == "_ASSET"}
-                <AssetDisplay
-                  asset={row}
-                  openInNewTab={openAssetLinksInNewTab}
-                />
-              {:else}
-                {row[column]}
-              {/if}
-            </td>
+          </th>
+          {#each headers as header, i}
+            <th
+              on:click={() => {
+                const colProp = columns[i];
+                if (sortColumn === colProp) {
+                  sortDirection = sortDirection === "asc" ? "desc" : "asc";
+                } else {
+                  sortColumn = colProp;
+                  sortDirection = "asc";
+                }
+              }}
+            >
+              {header}
+            </th>
           {/each}
           {#if haveGoogleData}
-            <td class="user">
-              {row.recentUsers[0]}
-              <button
-                class="w3-button w3-small"
-                on:click={() => {
-                  expandedUsers[row.Serial] = !expandedUsers[row.Serial];
-                }}>+</button
-              >
-              {#if expandedUsers[row.Serial]}
-                <ul>
-                  {#each row.recentUsers.slice(1) as user}
-                    <li>{user}</li>
-                  {/each}
-                </ul>
-              {/if}
-            </td>
-            <td class="session">
-              {row.lastUsed}<button
-                class="w3-button w3-small"
-                on:click={() => {
-                  expandedSessions[row.Serial] = !expandedSessions[row.Serial];
-                }}>+</button
-              >
-
-              {#if expandedSessions[row.Serial]}
-                <ul>
-                  {#each row.sessions as session}
-                    <li>{session}</li>
-                  {/each}
-                </ul>
-              {/if}
-            </td>
+            <th
+              on:click={() => {
+                if (sortColumn === "lastUserMatch") {
+                  sortDirection = sortDirection === "asc" ? "desc" : "asc";
+                } else {
+                  sortColumn = "lastUserMatch";
+                  sortDirection = "asc";
+                }
+              }}
+              style="cursor:pointer"
+            >
+              Last User?
+            </th>
+            <th
+              on:click={() => {
+                if (sortColumn === "lastUsed") {
+                  sortDirection = sortDirection === "asc" ? "desc" : "asc";
+                } else {
+                  sortColumn = "lastUsed";
+                  sortDirection = "asc";
+                }
+              }}
+              style="cursor:pointer"
+            >
+              Last Used
+            </th>
           {/if}
         </tr>
-      {/each}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {#each filteredData as row (row.Serial)}
+          <tr
+            class:highlight-stale={haveGoogleData && isStale(row.lastUsed)}
+            class:highlight-wrong-user={haveGoogleData && !row.lastUserMatch}
+          >
+            <td>
+              <input
+                type="checkbox"
+                checked={selectedAssetTags.has(row["Asset Tag"])}
+                on:change={() => toggleSelectRow(row)}
+              />
+            </td>
+            {#each columns as column, i (i)}
+              <td>
+                {#if column == "_ASSET"}
+                  <AssetDisplay
+                    asset={row}
+                    openInNewTab={openAssetLinksInNewTab}
+                  />
+                {:else}
+                  {row[column]}
+                {/if}
+              </td>
+            {/each}
+            {#if haveGoogleData}
+              <td class="user">
+                {row.recentUsers[0]}
+                <button
+                  class="w3-button w3-small"
+                  on:click={() => {
+                    expandedUsers[row.Serial] = !expandedUsers[row.Serial];
+                  }}>+</button
+                >
+                {#if expandedUsers[row.Serial]}
+                  <ul>
+                    {#each row.recentUsers.slice(1) as user}
+                      <li>{user}</li>
+                    {/each}
+                  </ul>
+                {/if}
+              </td>
+              <td class="session">
+                {row.lastUsed}<button
+                  class="w3-button w3-small"
+                  on:click={() => {
+                    expandedSessions[row.Serial] =
+                      !expandedSessions[row.Serial];
+                  }}>+</button
+                >
+
+                {#if expandedSessions[row.Serial]}
+                  <ul>
+                    {#each row.sessions as session}
+                      <li>{session}</li>
+                    {/each}
+                  </ul>
+                {/if}
+              </td>
+            {/if}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
 
   {#if showLostConfirm}
     <div
@@ -740,6 +832,23 @@
   }
   .data-exporter-wrap :global(button.w3-button) {
     margin-top: 0;
+  }
+  .report-table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .top-scrollbar {
+    overflow-x: auto;
+    overflow-y: hidden;
+    margin-bottom: 6px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .top-scrollbar-content {
+    height: 1px;
+  }
+  .report-table-grid {
+    min-width: 920px;
+    table-layout: auto;
   }
   .lost-confirm-modal {
     position: relative;

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -838,9 +838,15 @@
     -webkit-overflow-scrolling: touch;
   }
   .top-scrollbar {
+    position: sticky;
+    top: 0;
     overflow-x: auto;
     overflow-y: hidden;
     margin-bottom: 6px;
+    padding: 6px 0 4px;
+    background: #fff;
+    z-index: 20;
+    border-bottom: 1px solid #e0e0e0;
     -webkit-overflow-scrolling: touch;
   }
   .top-scrollbar-content {

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -8,6 +8,7 @@
   export let data;
   export let columns = [];
   export let filename = "data.csv";
+  export let openAssetLinksInNewTab = false;
   // sortColumn is now a property name (string)
   let sortColumn = columns[0] || "";
   let sortDirection = "asc";
@@ -577,7 +578,10 @@
           {#each columns as column, i (i)}
             <td>
               {#if column == "_ASSET"}
-                <AssetDisplay asset={row} />
+                <AssetDisplay
+                  asset={row}
+                  openInNewTab={openAssetLinksInNewTab}
+                />
               {:else}
                 {row[column]}
               {/if}

--- a/src/ui/reports/Reports.svelte
+++ b/src/ui/reports/Reports.svelte
@@ -25,8 +25,13 @@
   import { logger } from "@utils/log";
   import ReportTable from "./ReportTable.svelte";
   import Loader from "@components/Loader.svelte";
+  import StudentDeviceReport from "./StudentDeviceReport.svelte";
 
-  let activeTab: "studentLoans" | "staffLoans" | "nonLoaned" = "studentLoans";
+  let activeTab:
+    | "studentLoans"
+    | "staffLoans"
+    | "nonLoaned"
+    | "studentDeviceReport" = "studentLoans";
   let studentLoans = [];
   let staffLoans = [];
   let nonLoanedChromebooks = [];
@@ -216,10 +221,20 @@
     >
       Non-Loaned Chromebooks
     </button>
+    <button
+      class="w3-bar-item w3-button"
+      class:w3-blue={activeTab === "studentDeviceReport"}
+      on:click={() => (activeTab = "studentDeviceReport")}
+    >
+      Student Device Report
+    </button>
   </nav>
 
   <div class="w3-container">
-    {#if activeTab === "studentLoans"}
+    {#if activeTab === "studentDeviceReport"}
+      <StudentDeviceReport />
+    {:else}
+      {#if activeTab === "studentLoans"}
       <div class="w3-margin-top">
         <label for="yog" class="w3-margin-right">YOG:</label>
         <input
@@ -242,26 +257,26 @@
           <option value="Inactive">Inactive</option>
         </select>
       </div>
-    {/if}
+      {/if}
 
-    <button
-      class="w3-button w3-green w3-margin-top"
-      class:w3-white={loading === false && reportRun}
-      on:click={fetchData}
-      disabled={loading}
-    >
-      {#if reportRun}Rerun{:else}Run{/if} Report
-    </button>
-    <button
-      class="w3-button w3-green w3-margin-top"
-      on:click={checkAllStatuses}
-      disabled={loading || displayData.length === 0 || loginDataLoading}
-      title="Check Google for login data for the currently filtered machines."
-    >
-      Get Login Data
-    </button>
+      <button
+        class="w3-button w3-green w3-margin-top"
+        class:w3-white={loading === false && reportRun}
+        on:click={fetchData}
+        disabled={loading}
+      >
+        {#if reportRun}Rerun{:else}Run{/if} Report
+      </button>
+      <button
+        class="w3-button w3-green w3-margin-top"
+        on:click={checkAllStatuses}
+        disabled={loading || displayData.length === 0 || loginDataLoading}
+        title="Check Google for login data for the currently filtered machines."
+      >
+        Get Login Data
+      </button>
 
-    {#if loginDataLoading}
+      {#if loginDataLoading}
       <div class="progress-bar-container w3-margin-top">
         <div
           class="progress-bar"
@@ -274,20 +289,22 @@
             : 0}%
         </div>
       </div>
-    {/if}
+      {/if}
 
-    {#if loading}
-      <Loader working={true} text="Loading data" />
-    {:else}
-      <!-- Single ReportTable for all tabs -->
-      <ReportTable
-        bind:this={reportTable}
-        data={displayData}
-        loginDataReady={displayData.length && !!loginDataProgress}
-        {columns}
-        {headers}
-        {filename}
-      />
+      {#if loading}
+        <Loader working={true} text="Loading data" />
+      {:else}
+        <!-- Single ReportTable for all tabs -->
+        <ReportTable
+          bind:this={reportTable}
+          data={displayData}
+          loginDataReady={displayData.length && !!loginDataProgress}
+          {columns}
+          {headers}
+          {filename}
+          openAssetLinksInNewTab={true}
+        />
+      {/if}
     {/if}
   </div>
 </div>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -3,6 +3,7 @@
   import AssetDisplay from "@assets/AssetDisplay.svelte";
   import Loader from "@components/Loader.svelte";
   import DataExporter from "./DataExporter.svelte";
+  import { logger } from "@utils/log";
   import {
     buildStudentDeviceReport,
     flattenStudentDeviceReport,
@@ -40,6 +41,7 @@
   let rows: StudentDeviceReportRow[] = [];
   let loading = false;
   let error = "";
+  let errorDetails = "";
   let progress = { completed: 0, total: 0 };
   let sortColumn: SortColumn = "lastUsedMachineCount";
   let sortDirection: "asc" | "desc" = "desc";
@@ -47,9 +49,13 @@
   let expandedMachines = {};
   let tableScrollEl: HTMLDivElement | null = null;
   let topScrollEl: HTMLDivElement | null = null;
+  let viewportScrollEl: HTMLDivElement | null = null;
   let reportTableEl: HTMLTableElement | null = null;
   let topScrollWidth = 0;
   let showTopScroll = false;
+  let showViewportScroll = false;
+  let viewportScrollLeft = 0;
+  let viewportScrollWidth = 0;
   let resizeObserver: ResizeObserver | null = null;
 
   $: parsedEmails = parseEmails(listInput);
@@ -74,10 +80,26 @@
 
   function syncScrollMetrics() {
     if (!tableScrollEl || !reportTableEl) return;
+    const rect = tableScrollEl.getBoundingClientRect();
+
     topScrollWidth = reportTableEl.scrollWidth;
     showTopScroll = reportTableEl.scrollWidth > tableScrollEl.clientWidth + 1;
+    viewportScrollLeft = Math.max(0, rect.left);
+    viewportScrollWidth = Math.max(
+      0,
+      Math.min(rect.width, window.innerWidth - viewportScrollLeft),
+    );
+    showViewportScroll =
+      showTopScroll && rect.bottom > 0 && rect.top < window.innerHeight;
+
     if (topScrollEl && topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
       topScrollEl.scrollLeft = tableScrollEl.scrollLeft;
+    }
+    if (
+      viewportScrollEl &&
+      viewportScrollEl.scrollLeft !== tableScrollEl.scrollLeft
+    ) {
+      viewportScrollEl.scrollLeft = tableScrollEl.scrollLeft;
     }
   }
 
@@ -86,12 +108,34 @@
     if (tableScrollEl.scrollLeft !== topScrollEl.scrollLeft) {
       tableScrollEl.scrollLeft = topScrollEl.scrollLeft;
     }
+    if (
+      viewportScrollEl &&
+      viewportScrollEl.scrollLeft !== topScrollEl.scrollLeft
+    ) {
+      viewportScrollEl.scrollLeft = topScrollEl.scrollLeft;
+    }
+  }
+
+  function handleViewportScroll() {
+    if (!tableScrollEl || !viewportScrollEl) return;
+    if (tableScrollEl.scrollLeft !== viewportScrollEl.scrollLeft) {
+      tableScrollEl.scrollLeft = viewportScrollEl.scrollLeft;
+    }
+    if (topScrollEl && topScrollEl.scrollLeft !== viewportScrollEl.scrollLeft) {
+      topScrollEl.scrollLeft = viewportScrollEl.scrollLeft;
+    }
   }
 
   function handleTableScroll() {
-    if (!tableScrollEl || !topScrollEl) return;
-    if (topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
+    if (!tableScrollEl) return;
+    if (topScrollEl && topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
       topScrollEl.scrollLeft = tableScrollEl.scrollLeft;
+    }
+    if (
+      viewportScrollEl &&
+      viewportScrollEl.scrollLeft !== tableScrollEl.scrollLeft
+    ) {
+      viewportScrollEl.scrollLeft = tableScrollEl.scrollLeft;
     }
   }
 
@@ -108,7 +152,9 @@
 
   onMount(() => {
     const onResize = () => syncScrollMetrics();
+    const onScroll = () => syncScrollMetrics();
     window.addEventListener("resize", onResize);
+    window.addEventListener("scroll", onScroll, { passive: true });
     if (typeof ResizeObserver !== "undefined") {
       resizeObserver = new ResizeObserver(() => syncScrollMetrics());
       if (reportTableEl) {
@@ -119,6 +165,7 @@
 
     return () => {
       window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", onScroll);
       if (resizeObserver) {
         resizeObserver.disconnect();
       }
@@ -293,6 +340,7 @@
   async function runReport() {
     loading = true;
     error = "";
+    errorDetails = "";
     rows = [];
     progress = { completed: 0, total: 0 };
 
@@ -306,7 +354,13 @@
         },
       });
     } catch (err) {
-      error = err?.message || "Failed to build student device report.";
+      const reportError =
+        err instanceof Error
+          ? err
+          : new Error(String(err || "Failed to build student device report."));
+      error = reportError.message || "Failed to build student device report.";
+      errorDetails = reportError.stack || reportError.message;
+      logger.logError("StudentDeviceReport runReport failed", reportError);
     } finally {
       loading = false;
     }
@@ -365,13 +419,14 @@
 
   function recentUserSummary(machine: StudentDeviceReportMachine | null) {
     const users = recentUsers(machine)
-      .map((user) => user.email)
-      .filter(Boolean);
+      .map((user) => user?.email)
+      .filter((email): email is string => !!email);
     if (!machine || !users.length) return "";
+    const lastUserLower = (machine.lastUser || "").toLowerCase();
     const nextUsers = users
       .slice(1, 4)
       .filter(
-        (email) => email.toLowerCase() !== machine.lastUser.toLowerCase(),
+        (email) => !lastUserLower || email.toLowerCase() !== lastUserLower,
       );
     if (!nextUsers.length) return "No other recent users listed";
     return `Next recent: ${nextUsers.join(", ")}`;
@@ -519,7 +574,15 @@
   </div>
 
   {#if error}
-    <div class="w3-panel w3-pale-red w3-border">{error}</div>
+    <div class="w3-panel w3-pale-red w3-border">
+      <div>{error}</div>
+      {#if errorDetails}
+        <details class="error-details">
+          <summary>Details</summary>
+          <pre>{errorDetails}</pre>
+        </details>
+      {/if}
+    </div>
   {/if}
 
   {#if loading}
@@ -538,6 +601,19 @@
     </p>
 
     <div class="w3-responsive">
+      {#if showViewportScroll}
+        <div
+          class="viewport-scrollbar"
+          bind:this={viewportScrollEl}
+          on:scroll={handleViewportScroll}
+          style={`left: ${viewportScrollLeft}px; width: ${viewportScrollWidth}px;`}
+        >
+          <div
+            class="top-scrollbar-content"
+            style={`width: ${topScrollWidth}px;`}
+          ></div>
+        </div>
+      {/if}
       {#if showTopScroll}
         <div
           class="top-scrollbar"
@@ -732,13 +808,31 @@
     -webkit-overflow-scrolling: touch;
   }
   .top-scrollbar {
+    position: sticky;
+    top: 0;
     overflow-x: auto;
     overflow-y: hidden;
     margin-bottom: 6px;
+    padding: 6px 0 4px;
+    background: #fff;
+    z-index: 20;
+    border-bottom: 1px solid #e0e0e0;
     -webkit-overflow-scrolling: touch;
   }
   .top-scrollbar-content {
     height: 1px;
+  }
+  .viewport-scrollbar {
+    position: fixed;
+    bottom: 10px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid #d9d9d9;
+    border-radius: 6px;
+    z-index: 1200;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.16);
+    -webkit-overflow-scrolling: touch;
   }
   .report-table-grid {
     min-width: 980px;
@@ -810,5 +904,13 @@
   .status-unknown {
     background: #eeeeee;
     color: #424242;
+  }
+  .error-details {
+    margin-top: 8px;
+  }
+  .error-details pre {
+    white-space: pre-wrap;
+    margin: 6px 0 0;
+    font-size: 12px;
   }
 </style>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -14,9 +14,17 @@
     | "student"
     | "yog"
     | "status"
+    | "summary"
     | "currentLoanCount"
     | "lastUsedMachineCount"
     | "problemCount";
+
+  type SummaryFilter =
+    | "all"
+    | "attention"
+    | "loginMismatch"
+    | "excludeCheckedInAfterUse"
+    | "checkedInAfterUseOnly";
 
   type DisplayRow = {
     key: string;
@@ -35,6 +43,7 @@
   let progress = { completed: 0, total: 0 };
   let sortColumn: SortColumn = "lastUsedMachineCount";
   let sortDirection: "asc" | "desc" = "desc";
+  let summaryFilter: SummaryFilter = "all";
   let expandedMachines = {};
   let tableScrollEl: HTMLDivElement | null = null;
   let topScrollEl: HTMLDivElement | null = null;
@@ -49,7 +58,13 @@
     ((inputMode === "yog" && selectedYOG.trim()) ||
       (inputMode === "list" && parsedEmails.length));
   $: sortedRows = sortRows(rows, sortColumn, sortDirection);
-  $: displayRows = flattenDisplayRows(sortedRows);
+  $: allDisplayRows = flattenDisplayRows(sortedRows);
+  $: displayRows = filterAndSortDisplayRows(
+    allDisplayRows,
+    summaryFilter,
+    sortColumn,
+    sortDirection,
+  );
   $: exportRows = flattenStudentDeviceReport(sortedRows);
   $: filename = [
     inputMode === "yog" ? selectedYOG || "students" : "student-list",
@@ -140,6 +155,10 @@
     column: SortColumn,
     direction: "asc" | "desc",
   ) {
+    if (column === "summary") {
+      return [...reportRows];
+    }
+
     const sorted = [...reportRows];
     sorted.sort((a, b) => {
       let aValue: string | number;
@@ -185,6 +204,82 @@
         machineIndex,
       }));
     }) as DisplayRow[];
+  }
+
+  function summarySortRank(machine: StudentDeviceReportMachine | null) {
+    if (!machine) return 99;
+
+    const ranks = {
+      signedOutToOther: 1,
+      signedOutToStaff: 2,
+      checkedInAfterGoogleUse: 3,
+      checkedInUnknown: 4,
+      unknown: 5,
+      checkedInAfterUse: 6,
+      checkedInSameDay: 7,
+      normal: 8,
+    };
+
+    return ranks[machine.status] ?? 98;
+  }
+
+  function matchesSummaryFilter(displayRow: DisplayRow, filter: SummaryFilter) {
+    const status = displayRow.machine?.status;
+
+    if (filter === "all") return true;
+    if (!status) return filter === "excludeCheckedInAfterUse";
+
+    if (filter === "attention") {
+      return !["normal", "checkedInAfterUse", "checkedInSameDay"].includes(
+        status,
+      );
+    }
+
+    if (filter === "loginMismatch") {
+      return ["signedOutToOther", "signedOutToStaff"].includes(status);
+    }
+
+    if (filter === "excludeCheckedInAfterUse") {
+      return status !== "checkedInAfterUse";
+    }
+
+    if (filter === "checkedInAfterUseOnly") {
+      return status === "checkedInAfterUse";
+    }
+
+    return true;
+  }
+
+  function filterAndSortDisplayRows(
+    reportRows: DisplayRow[],
+    filter: SummaryFilter,
+    column: SortColumn,
+    direction: "asc" | "desc",
+  ) {
+    const filtered = reportRows.filter((displayRow) =>
+      matchesSummaryFilter(displayRow, filter),
+    );
+
+    if (column !== "summary") {
+      return filtered;
+    }
+
+    const sorted = [...filtered];
+    sorted.sort((a, b) => {
+      const aRank = summarySortRank(a.machine);
+      const bRank = summarySortRank(b.machine);
+      if (aRank !== bRank) {
+        return direction === "asc" ? aRank - bRank : bRank - aRank;
+      }
+
+      const aStudent = a.row.student.Email || a.row.student.Name || "";
+      const bStudent = b.row.student.Email || b.row.student.Name || "";
+      if (aStudent < bStudent) return -1;
+      if (aStudent > bStudent) return 1;
+      return 0;
+    });
+
+    return sorted;
   }
 
   async function handleFileUpload(event: Event) {
@@ -376,6 +471,19 @@
       </select>
     </label>
 
+    <label>
+      Summary Filter
+      <select class="w3-select w3-border" bind:value={summaryFilter}>
+        <option value="all">All</option>
+        <option value="attention">Needs Attention</option>
+        <option value="loginMismatch">Login Mismatch Only</option>
+        <option value="excludeCheckedInAfterUse">
+          Exclude Checked In After Use
+        </option>
+        <option value="checkedInAfterUseOnly">Checked In After Use Only</option>
+      </select>
+    </label>
+
     <div class="actions">
       <button
         class="w3-button w3-green"
@@ -424,7 +532,8 @@
   {:else if rows.length}
     <p>
       Showing <b>{sortedRows.length}</b> students and
-      <b>{displayRows.length}</b> report rows with
+      <b>{displayRows.length}</b> of <b>{allDisplayRows.length}</b> report rows
+      with
       <b>{exportRows.filter((row) => row.Serial).length}</b> last-used machines
     </p>
 
@@ -457,7 +566,7 @@
               <th>Machine</th>
               <th>Last Activity</th>
               <th>Checkout Status</th>
-              <th>Summary</th>
+              <th on:click={() => setSort("summary")}>Summary</th>
               <th on:click={() => setSort("lastUsedMachineCount")}>Count</th>
             </tr>
           </thead>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy, onMount, tick } from "svelte";
   import AssetDisplay from "@assets/AssetDisplay.svelte";
   import Loader from "@components/Loader.svelte";
   import DataExporter from "./DataExporter.svelte";
@@ -35,6 +36,12 @@
   let sortColumn: SortColumn = "lastUsedMachineCount";
   let sortDirection: "asc" | "desc" = "desc";
   let expandedMachines = {};
+  let tableScrollEl: HTMLDivElement | null = null;
+  let topScrollEl: HTMLDivElement | null = null;
+  let reportTableEl: HTMLTableElement | null = null;
+  let topScrollWidth = 0;
+  let showTopScroll = false;
+  let resizeObserver: ResizeObserver | null = null;
 
   $: parsedEmails = parseEmails(listInput);
   $: canRun =
@@ -49,6 +56,65 @@
     selectedStudentStatus || "all-statuses",
     "student-device-report.csv",
   ].join("-");
+
+  function syncScrollMetrics() {
+    if (!tableScrollEl || !reportTableEl) return;
+    topScrollWidth = reportTableEl.scrollWidth;
+    showTopScroll = reportTableEl.scrollWidth > tableScrollEl.clientWidth + 1;
+    if (topScrollEl && topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
+      topScrollEl.scrollLeft = tableScrollEl.scrollLeft;
+    }
+  }
+
+  function handleTopScroll() {
+    if (!tableScrollEl || !topScrollEl) return;
+    if (tableScrollEl.scrollLeft !== topScrollEl.scrollLeft) {
+      tableScrollEl.scrollLeft = topScrollEl.scrollLeft;
+    }
+  }
+
+  function handleTableScroll() {
+    if (!tableScrollEl || !topScrollEl) return;
+    if (topScrollEl.scrollLeft !== tableScrollEl.scrollLeft) {
+      topScrollEl.scrollLeft = tableScrollEl.scrollLeft;
+    }
+  }
+
+  let syncPending = false;
+  async function scheduleSyncMetrics() {
+    if (syncPending) return;
+    syncPending = true;
+    await tick();
+    syncPending = false;
+    syncScrollMetrics();
+  }
+
+  $: displayRows.length, sortedRows.length, scheduleSyncMetrics();
+
+  onMount(() => {
+    const onResize = () => syncScrollMetrics();
+    window.addEventListener("resize", onResize);
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => syncScrollMetrics());
+      if (reportTableEl) {
+        resizeObserver.observe(reportTableEl);
+      }
+    }
+    scheduleSyncMetrics();
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  });
+
+  onDestroy(() => {
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    }
+  });
 
   function parseEmails(value: string) {
     return value
@@ -72,7 +138,7 @@
   function sortRows(
     reportRows: StudentDeviceReportRow[],
     column: SortColumn,
-    direction: "asc" | "desc"
+    direction: "asc" | "desc",
   ) {
     const sorted = [...reportRows];
     sorted.sort((a, b) => {
@@ -104,7 +170,12 @@
     return reportRows.flatMap((row) => {
       if (!row.machines.length) {
         return [
-          { key: `${row.student._id}:none`, row, machine: null, machineIndex: 0 },
+          {
+            key: `${row.student._id}:none`,
+            row,
+            machine: null,
+            machineIndex: 0,
+          },
         ];
       }
       return row.machines.map((machine, machineIndex) => ({
@@ -204,7 +275,9 @@
     if (!machine || !users.length) return "";
     const nextUsers = users
       .slice(1, 4)
-      .filter((email) => email.toLowerCase() !== machine.lastUser.toLowerCase());
+      .filter(
+        (email) => email.toLowerCase() !== machine.lastUser.toLowerCase(),
+      );
     if (!nextUsers.length) return "No other recent users listed";
     return `Next recent: ${nextUsers.join(", ")}`;
   }
@@ -220,7 +293,9 @@
     if (!machine) return "";
     if (machine.currentOwner) {
       return `Signed out to ${machine.currentOwner}${
-        machine.checkoutTime ? ` on ${formatDateTime(machine.checkoutTime)}` : ""
+        machine.checkoutTime
+          ? ` on ${formatDateTime(machine.checkoutTime)}`
+          : ""
       }`;
     }
     if (machine.checkInTime) {
@@ -354,126 +429,154 @@
     </p>
 
     <div class="w3-responsive">
-      <table class="w3-table w3-bordered w3-striped report-table">
-        <thead>
-          <tr>
-            <th on:click={() => setSort("student")}>Student</th>
-            <th on:click={() => setSort("status")}>Status</th>
-            <th>Machine</th>
-            <th>Last Activity</th>
-            <th>Checkout Status</th>
-            <th>Summary</th>
-            <th on:click={() => setSort("lastUsedMachineCount")}>Count</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each displayRows as displayRow (displayRow.key)}
-            <tr class:has-warning={isWarningMachine(displayRow.machine)}>
-              <td>
-                <b>{displayRow.row.student.Email}</b>
-                <div class="w3-small">{displayRow.row.student.Name}</div>
-                <div class="w3-small">YOG {displayRow.row.student.YOG}</div>
-              </td>
-              <td>
-                <span
-                  class:inactive={displayRow.row.student.Status === "Inactive"}
-                  class="student-status"
-                >
-                  {displayRow.row.student.Status}
-                </span>
-                <div class="w3-small">
-                  {displayRow.row.currentLoanCount} currently signed out
-                  {#if displayRow.row.problemCount}
-                    | {displayRow.row.problemCount} warning{displayRow.row
-                      .problemCount === 1
-                      ? ""
-                      : "s"}
-                  {/if}
-                </div>
-              </td>
-              <td>
-                {#if displayRow.machine}
-                  <div class="machine-summary">
-                    {#if displayRow.machine.asset}
-                      <AssetDisplay
-                        asset={displayRow.machine.asset}
-                        openInNewTab={true}
-                        showOwner={true}
-                      />
-                    {:else}
-                      <div>
-                        <b>{displayRow.machine.assetTag}</b>
-                        <div class="w3-monospace w3-small">
-                          s/n {displayRow.machine.serial}
-                        </div>
-                      </div>
+      {#if showTopScroll}
+        <div
+          class="top-scrollbar"
+          bind:this={topScrollEl}
+          on:scroll={handleTopScroll}
+        >
+          <div
+            class="top-scrollbar-content"
+            style={`width: ${topScrollWidth}px;`}
+          ></div>
+        </div>
+      {/if}
+      <div
+        class="report-table-scroll"
+        bind:this={tableScrollEl}
+        on:scroll={handleTableScroll}
+      >
+        <table
+          bind:this={reportTableEl}
+          class="w3-table w3-bordered w3-striped report-table report-table-grid"
+        >
+          <thead>
+            <tr>
+              <th on:click={() => setSort("student")}>Student</th>
+              <th on:click={() => setSort("status")}>Status</th>
+              <th>Machine</th>
+              <th>Last Activity</th>
+              <th>Checkout Status</th>
+              <th>Summary</th>
+              <th on:click={() => setSort("lastUsedMachineCount")}>Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each displayRows as displayRow (displayRow.key)}
+              <tr class:has-warning={isWarningMachine(displayRow.machine)}>
+                <td>
+                  <b>{displayRow.row.student.Email}</b>
+                  <div class="w3-small">{displayRow.row.student.Name}</div>
+                  <div class="w3-small">YOG {displayRow.row.student.YOG}</div>
+                </td>
+                <td>
+                  <span
+                    class:inactive={displayRow.row.student.Status ===
+                      "Inactive"}
+                    class="student-status"
+                  >
+                    {displayRow.row.student.Status}
+                  </span>
+                  <div class="w3-small">
+                    {displayRow.row.currentLoanCount} currently signed out
+                    {#if displayRow.row.problemCount}
+                      | {displayRow.row.problemCount} warning{displayRow.row
+                        .problemCount === 1
+                        ? ""
+                        : "s"}
                     {/if}
                   </div>
-                {:else}
-                  <span class="w3-text-gray">No Google last-used machines</span>
-                {/if}
-              </td>
-              <td>
-                {#if displayRow.machine}
-                  <div>
-                    {activitySummary(displayRow.machine) ||
-                      formatDate(displayRow.machine.lastUsed)}
-                  </div>
-                  <div class="w3-small">
-                    {recentUserSummary(displayRow.machine)}
-                    <button
-                      class="w3-button w3-tiny w3-border expand-button"
-                      on:click={() => toggleExpanded(displayRow.key)}
-                    >
-                      {expandedMachines[displayRow.key] ? "-" : "+"}
-                    </button>
-                  </div>
-                {/if}
-              </td>
-              <td>{formatCheckoutStatus(displayRow.machine)}</td>
-              <td>
-                {#if displayRow.machine}
-                  <span class={statusClass(displayRow.machine)}>
-                    {displayRow.machine.statusLabel}
-                  </span>
-                {:else}
-                  <span class="w3-text-gray">No Google latest-user machines</span>
-                {/if}
-              </td>
-              <td>{formatCount(displayRow)}</td>
-            </tr>
-            {#if expandedMachines[displayRow.key] && displayRow.machine}
-              <tr class="expanded-row">
-                <td colspan="7">
-                  <div class="expanded-grid">
-                    <div>
-                      <h4>Recent Users</h4>
-                      <ol>
-                        {#each recentUsers(displayRow.machine) as user}
-                          <li>{user.email || user.type}</li>
-                        {/each}
-                      </ol>
-                    </div>
-                    <div>
-                      <h4>Device Activity</h4>
-                      <ol>
-                        {#each [...(displayRow.machine.googleData?.activeTimeRanges || [])].reverse().slice(0, 10) as range}
-                          <li>
-                            {formatDate(range.date)}
-                            {#if formatDuration(range.activeTime)}
-                              for {formatDuration(range.activeTime)}
-                            {/if}
-                          </li>
-                        {/each}
-                      </ol>
-                    </div>
-                  </div>
                 </td>
+                <td>
+                  {#if displayRow.machine}
+                    <div class="machine-summary">
+                      {#if displayRow.machine.asset}
+                        <AssetDisplay
+                          asset={displayRow.machine.asset}
+                          openInNewTab={true}
+                          showOwner={true}
+                        />
+                      {:else}
+                        <div>
+                          <b>{displayRow.machine.assetTag}</b>
+                          <div class="w3-monospace w3-small">
+                            s/n {displayRow.machine.serial}
+                          </div>
+                        </div>
+                      {/if}
+                    </div>
+                  {:else}
+                    <span class="w3-text-gray"
+                      >No Google last-used machines</span
+                    >
+                  {/if}
+                </td>
+                <td>
+                  {#if displayRow.machine}
+                    <div>
+                      {activitySummary(displayRow.machine) ||
+                        formatDate(displayRow.machine.lastUsed)}
+                    </div>
+                    <div class="w3-small">
+                      {recentUserSummary(displayRow.machine)}
+                      <button
+                        class="w3-button w3-tiny w3-border expand-button"
+                        on:click={() => toggleExpanded(displayRow.key)}
+                      >
+                        {expandedMachines[displayRow.key] ? "-" : "+"}
+                      </button>
+                    </div>
+                  {/if}
+                </td>
+                <td>{formatCheckoutStatus(displayRow.machine)}</td>
+                <td>
+                  {#if displayRow.machine}
+                    <span class={statusClass(displayRow.machine)}>
+                      {displayRow.machine.statusLabel}
+                    </span>
+                  {:else}
+                    <span class="w3-text-gray"
+                      >No Google latest-user machines</span
+                    >
+                  {/if}
+                </td>
+                <td>{formatCount(displayRow)}</td>
               </tr>
-            {/if}
-          {/each}
-        </tbody>
-      </table>
+              {#if expandedMachines[displayRow.key] && displayRow.machine}
+                <tr class="expanded-row">
+                  <td colspan="7">
+                    <div class="expanded-grid">
+                      <div>
+                        <h4>Recent Users</h4>
+                        <ol>
+                          {#each recentUsers(displayRow.machine) as user}
+                            <li>{user.email || user.type}</li>
+                          {/each}
+                        </ol>
+                      </div>
+                      <div>
+                        <h4>Device Activity</h4>
+                        <ol>
+                          {#each [...(displayRow.machine.googleData?.activeTimeRanges || [])]
+                            .reverse()
+                            .slice(0, 10) as range}
+                            <li>
+                              {formatDate(range.date)}
+                              {#if formatDuration(range.activeTime)}
+                                for {formatDuration(range.activeTime)}
+                              {/if}
+                            </li>
+                          {/each}
+                        </ol>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {/if}
+            {/each}
+          </tbody>
+        </table>
+      </div>
     </div>
   {/if}
 </section>
@@ -514,6 +617,23 @@
   }
   .report-table td {
     vertical-align: top;
+  }
+  .report-table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .top-scrollbar {
+    overflow-x: auto;
+    overflow-y: hidden;
+    margin-bottom: 6px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .top-scrollbar-content {
+    height: 1px;
+  }
+  .report-table-grid {
+    min-width: 980px;
+    table-layout: auto;
   }
   .has-warning {
     background-color: #fff8e1;

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -1,0 +1,585 @@
+<script lang="ts">
+  import AssetDisplay from "@assets/AssetDisplay.svelte";
+  import Loader from "@components/Loader.svelte";
+  import DataExporter from "./DataExporter.svelte";
+  import {
+    buildStudentDeviceReport,
+    flattenStudentDeviceReport,
+    type StudentDeviceReportMachine,
+    type StudentDeviceReportRow,
+  } from "@data/studentDeviceReport";
+
+  type SortColumn =
+    | "student"
+    | "yog"
+    | "status"
+    | "currentLoanCount"
+    | "lastUsedMachineCount"
+    | "problemCount";
+
+  type DisplayRow = {
+    key: string;
+    row: StudentDeviceReportRow;
+    machine: StudentDeviceReportMachine | null;
+    machineIndex: number;
+  };
+
+  let inputMode: "yog" | "list" = "yog";
+  let selectedYOG = "";
+  let selectedStudentStatus = "";
+  let listInput = "";
+  let rows: StudentDeviceReportRow[] = [];
+  let loading = false;
+  let error = "";
+  let progress = { completed: 0, total: 0 };
+  let sortColumn: SortColumn = "lastUsedMachineCount";
+  let sortDirection: "asc" | "desc" = "desc";
+  let expandedMachines = {};
+
+  $: parsedEmails = parseEmails(listInput);
+  $: canRun =
+    !loading &&
+    ((inputMode === "yog" && selectedYOG.trim()) ||
+      (inputMode === "list" && parsedEmails.length));
+  $: sortedRows = sortRows(rows, sortColumn, sortDirection);
+  $: displayRows = flattenDisplayRows(sortedRows);
+  $: exportRows = flattenStudentDeviceReport(sortedRows);
+  $: filename = [
+    inputMode === "yog" ? selectedYOG || "students" : "student-list",
+    selectedStudentStatus || "all-statuses",
+    "student-device-report.csv",
+  ].join("-");
+
+  function parseEmails(value: string) {
+    return value
+      .split(/[,\n\r\t ;]+/)
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean);
+  }
+
+  function setSort(column: SortColumn) {
+    if (sortColumn === column) {
+      sortDirection = sortDirection === "asc" ? "desc" : "asc";
+    } else {
+      sortColumn = column;
+      sortDirection =
+        column === "student" || column === "yog" || column === "status"
+          ? "asc"
+          : "desc";
+    }
+  }
+
+  function sortRows(
+    reportRows: StudentDeviceReportRow[],
+    column: SortColumn,
+    direction: "asc" | "desc"
+  ) {
+    const sorted = [...reportRows];
+    sorted.sort((a, b) => {
+      let aValue: string | number;
+      let bValue: string | number;
+
+      if (column === "student") {
+        aValue = a.student.Email || a.student.Name || "";
+        bValue = b.student.Email || b.student.Name || "";
+      } else if (column === "yog") {
+        aValue = a.student.YOG || "";
+        bValue = b.student.YOG || "";
+      } else if (column === "status") {
+        aValue = a.student.Status || "";
+        bValue = b.student.Status || "";
+      } else {
+        aValue = a[column];
+        bValue = b[column];
+      }
+
+      if (aValue < bValue) return direction === "asc" ? -1 : 1;
+      if (aValue > bValue) return direction === "asc" ? 1 : -1;
+      return 0;
+    });
+    return sorted;
+  }
+
+  function flattenDisplayRows(reportRows: StudentDeviceReportRow[]) {
+    return reportRows.flatMap((row) => {
+      if (!row.machines.length) {
+        return [
+          { key: `${row.student._id}:none`, row, machine: null, machineIndex: 0 },
+        ];
+      }
+      return row.machines.map((machine, machineIndex) => ({
+        key: `${row.student._id}:${machine.serial || machine.assetTag}`,
+        row,
+        machine,
+        machineIndex,
+      }));
+    }) as DisplayRow[];
+  }
+
+  async function handleFileUpload(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    listInput = await file.text();
+    inputMode = "list";
+  }
+
+  async function runReport() {
+    loading = true;
+    error = "";
+    rows = [];
+    progress = { completed: 0, total: 0 };
+
+    try {
+      rows = await buildStudentDeviceReport({
+        yog: inputMode === "yog" ? selectedYOG.trim() : undefined,
+        emails: inputMode === "list" ? parsedEmails : undefined,
+        status: selectedStudentStatus || undefined,
+        onProgress: ({ completed, total }) => {
+          progress = { completed, total };
+        },
+      });
+    } catch (err) {
+      error = err?.message || "Failed to build student device report.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  function statusClass(machine: StudentDeviceReportMachine) {
+    return `status-pill status-${machine.status}`;
+  }
+
+  function isWarningMachine(machine: StudentDeviceReportMachine | null) {
+    if (!machine) return false;
+    return !["normal", "checkedInAfterUse"].includes(machine.status);
+  }
+
+  function formatDate(date: string | null) {
+    if (!date) return "Unknown";
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) return date;
+    return parsed.toLocaleDateString();
+  }
+
+  function formatDateTime(date: string | null) {
+    if (!date) return "Unknown";
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) return date;
+    return parsed.toLocaleString();
+  }
+
+  function formatDuration(ms: number | null | undefined) {
+    if (!ms && ms !== 0) return "";
+    const totalMinutes = Math.round(ms / 1000 / 60);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours) return `${hours}:${String(minutes).padStart(2, "0")}`;
+    return `${minutes} min`;
+  }
+
+  function latestActivity(machine: StudentDeviceReportMachine | null) {
+    if (!machine) return null;
+    const ranges = machine.googleData?.activeTimeRanges || [];
+    return ranges.length ? ranges[ranges.length - 1] : null;
+  }
+
+  function activitySummary(machine: StudentDeviceReportMachine | null) {
+    const activity = latestActivity(machine);
+    if (!machine || !activity) return "";
+    const duration = formatDuration(activity.activeTime);
+    return duration
+      ? `${formatDate(activity.date)} for ${duration}`
+      : formatDate(activity.date);
+  }
+
+  function recentUsers(machine: StudentDeviceReportMachine | null) {
+    return machine?.googleData?.recentUsers || [];
+  }
+
+  function recentUserSummary(machine: StudentDeviceReportMachine | null) {
+    const users = recentUsers(machine)
+      .map((user) => user.email)
+      .filter(Boolean);
+    if (!machine || !users.length) return "";
+    const nextUsers = users
+      .slice(1, 4)
+      .filter((email) => email.toLowerCase() !== machine.lastUser.toLowerCase());
+    if (!nextUsers.length) return "No other recent users listed";
+    return `Next recent: ${nextUsers.join(", ")}`;
+  }
+
+  function toggleExpanded(key: string) {
+    expandedMachines = {
+      ...expandedMachines,
+      [key]: !expandedMachines[key],
+    };
+  }
+
+  function formatCheckoutStatus(machine: StudentDeviceReportMachine | null) {
+    if (!machine) return "";
+    if (machine.currentOwner) {
+      return `Signed out to ${machine.currentOwner}${
+        machine.checkoutTime ? ` on ${formatDateTime(machine.checkoutTime)}` : ""
+      }`;
+    }
+    if (machine.checkInTime) {
+      return `Checked in ${formatDateTime(machine.checkInTime)}`;
+    }
+    if (machine.status === "unknown") {
+      return "Not found in inventory";
+    }
+    return "Checked in; no check-in date found";
+  }
+
+  function formatCount(displayRow: DisplayRow) {
+    if (!displayRow.machine) {
+      return "No machines where this student is Google latest user";
+    }
+    return `Machine ${displayRow.machineIndex + 1} of ${
+      displayRow.row.lastUsedMachineCount
+    } this student was the Google latest user`;
+  }
+</script>
+
+<section class="student-device-report">
+  <div class="controls w3-border-bottom">
+    <div class="mode-buttons" aria-label="Student selection mode">
+      <button
+        class="w3-button w3-border"
+        class:w3-blue={inputMode === "yog"}
+        on:click={() => (inputMode = "yog")}
+      >
+        Class Year
+      </button>
+      <button
+        class="w3-button w3-border"
+        class:w3-blue={inputMode === "list"}
+        on:click={() => (inputMode = "list")}
+      >
+        Uploaded List
+      </button>
+    </div>
+
+    {#if inputMode === "yog"}
+      <label>
+        YOG
+        <input
+          class="w3-input w3-border"
+          type="text"
+          placeholder="2030"
+          bind:value={selectedYOG}
+        />
+      </label>
+    {:else}
+      <label class="email-list">
+        Student Emails
+        <textarea
+          class="w3-input w3-border"
+          rows="4"
+          bind:value={listInput}
+          placeholder="student@example.org"
+        ></textarea>
+      </label>
+      <label>
+        Upload
+        <input
+          class="w3-input w3-border"
+          type="file"
+          accept=".csv,.txt"
+          on:change={handleFileUpload}
+        />
+      </label>
+    {/if}
+
+    <label>
+      Status
+      <select class="w3-select w3-border" bind:value={selectedStudentStatus}>
+        <option value="">All</option>
+        <option value="Active">Active</option>
+        <option value="Inactive">Inactive</option>
+      </select>
+    </label>
+
+    <div class="actions">
+      <button
+        class="w3-button w3-green"
+        disabled={!canRun}
+        on:click={runReport}
+      >
+        {rows.length ? "Rerun" : "Run"} Report
+      </button>
+      {#if exportRows.length}
+        <DataExporter
+          items={exportRows}
+          {filename}
+          headers={[
+            "Student",
+            "Name",
+            "YOG",
+            "Status",
+            "Machine Number",
+            "Machine Count",
+            "Asset Tag",
+            "Serial",
+            "Last Activity Date",
+            "Last Activity Duration",
+            "Recent Users",
+            "Checkout Status",
+            "Checkout Time",
+            "Check-In Time",
+            "Summary",
+          ]}
+        />
+      {/if}
+    </div>
+  </div>
+
+  {#if error}
+    <div class="w3-panel w3-pale-red w3-border">{error}</div>
+  {/if}
+
+  {#if loading}
+    <Loader
+      working={true}
+      text={progress.total
+        ? `Checking Google Admin: ${progress.completed}/${progress.total}`
+        : "Loading students and inventory"}
+    />
+  {:else if rows.length}
+    <p>
+      Showing <b>{sortedRows.length}</b> students and
+      <b>{displayRows.length}</b> report rows with
+      <b>{exportRows.filter((row) => row.Serial).length}</b> last-used machines
+    </p>
+
+    <div class="w3-responsive">
+      <table class="w3-table w3-bordered w3-striped report-table">
+        <thead>
+          <tr>
+            <th on:click={() => setSort("student")}>Student</th>
+            <th on:click={() => setSort("status")}>Status</th>
+            <th>Machine</th>
+            <th>Last Activity</th>
+            <th>Checkout Status</th>
+            <th>Summary</th>
+            <th on:click={() => setSort("lastUsedMachineCount")}>Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each displayRows as displayRow (displayRow.key)}
+            <tr class:has-warning={isWarningMachine(displayRow.machine)}>
+              <td>
+                <b>{displayRow.row.student.Email}</b>
+                <div class="w3-small">{displayRow.row.student.Name}</div>
+                <div class="w3-small">YOG {displayRow.row.student.YOG}</div>
+              </td>
+              <td>
+                <span
+                  class:inactive={displayRow.row.student.Status === "Inactive"}
+                  class="student-status"
+                >
+                  {displayRow.row.student.Status}
+                </span>
+                <div class="w3-small">
+                  {displayRow.row.currentLoanCount} currently signed out
+                  {#if displayRow.row.problemCount}
+                    | {displayRow.row.problemCount} warning{displayRow.row
+                      .problemCount === 1
+                      ? ""
+                      : "s"}
+                  {/if}
+                </div>
+              </td>
+              <td>
+                {#if displayRow.machine}
+                  <div class="machine-summary">
+                    {#if displayRow.machine.asset}
+                      <AssetDisplay
+                        asset={displayRow.machine.asset}
+                        openInNewTab={true}
+                        showOwner={true}
+                      />
+                    {:else}
+                      <div>
+                        <b>{displayRow.machine.assetTag}</b>
+                        <div class="w3-monospace w3-small">
+                          s/n {displayRow.machine.serial}
+                        </div>
+                      </div>
+                    {/if}
+                  </div>
+                {:else}
+                  <span class="w3-text-gray">No Google last-used machines</span>
+                {/if}
+              </td>
+              <td>
+                {#if displayRow.machine}
+                  <div>
+                    {activitySummary(displayRow.machine) ||
+                      formatDate(displayRow.machine.lastUsed)}
+                  </div>
+                  <div class="w3-small">
+                    {recentUserSummary(displayRow.machine)}
+                    <button
+                      class="w3-button w3-tiny w3-border expand-button"
+                      on:click={() => toggleExpanded(displayRow.key)}
+                    >
+                      {expandedMachines[displayRow.key] ? "-" : "+"}
+                    </button>
+                  </div>
+                {/if}
+              </td>
+              <td>{formatCheckoutStatus(displayRow.machine)}</td>
+              <td>
+                {#if displayRow.machine}
+                  <span class={statusClass(displayRow.machine)}>
+                    {displayRow.machine.statusLabel}
+                  </span>
+                {:else}
+                  <span class="w3-text-gray">No Google latest-user machines</span>
+                {/if}
+              </td>
+              <td>{formatCount(displayRow)}</td>
+            </tr>
+            {#if expandedMachines[displayRow.key] && displayRow.machine}
+              <tr class="expanded-row">
+                <td colspan="7">
+                  <div class="expanded-grid">
+                    <div>
+                      <h4>Recent Users</h4>
+                      <ol>
+                        {#each recentUsers(displayRow.machine) as user}
+                          <li>{user.email || user.type}</li>
+                        {/each}
+                      </ol>
+                    </div>
+                    <div>
+                      <h4>Device Activity</h4>
+                      <ol>
+                        {#each [...(displayRow.machine.googleData?.activeTimeRanges || [])].reverse().slice(0, 10) as range}
+                          <li>
+                            {formatDate(range.date)}
+                            {#if formatDuration(range.activeTime)}
+                              for {formatDuration(range.activeTime)}
+                            {/if}
+                          </li>
+                        {/each}
+                      </ol>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .student-device-report {
+    padding-top: 16px;
+  }
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+    padding-bottom: 16px;
+  }
+  .controls label {
+    min-width: 150px;
+    font-weight: bold;
+  }
+  .mode-buttons {
+    display: flex;
+    gap: 4px;
+  }
+  .email-list {
+    min-width: min(460px, 100%);
+  }
+  .actions {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+  }
+  .actions :global(button.w3-button) {
+    margin-top: 0;
+  }
+  th {
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .report-table td {
+    vertical-align: top;
+  }
+  .has-warning {
+    background-color: #fff8e1;
+  }
+  .student-status {
+    font-weight: bold;
+  }
+  .inactive {
+    color: #757575;
+    text-decoration: line-through;
+  }
+  .machine-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: flex-start;
+  }
+  .expand-button {
+    margin-left: 6px;
+    padding: 0 6px;
+  }
+  .expanded-row td {
+    background: #f7f7f7;
+  }
+  .expanded-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+  }
+  .expanded-grid h4 {
+    margin: 4px 0;
+    font-size: 14px;
+    font-weight: bold;
+  }
+  .expanded-grid ol {
+    margin: 0;
+    padding-left: 20px;
+  }
+  .status-pill {
+    border-radius: 4px;
+    display: inline-block;
+    font-size: 12px;
+    font-weight: bold;
+    padding: 2px 6px;
+  }
+  .status-normal {
+    background: #dff3df;
+    color: #1b5e20;
+  }
+  .status-checkedInAfterUse,
+  .status-checkedInSameDay {
+    background: #dff3df;
+    color: #1b5e20;
+  }
+  .status-signedOutToOther,
+  .status-signedOutToStaff,
+  .status-checkedInAfterGoogleUse {
+    background: #ffd6d6;
+    color: #8b0000;
+  }
+  .status-checkedInUnknown {
+    background: #fff4c2;
+    color: #7a5600;
+  }
+  .status-unknown {
+    background: #eeeeee;
+    color: #424242;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add a report-oriented student query and student device aggregation layer
- add a Student Device Report tab with YOG/list/status filters, Google Admin enrichment, signout/check-in comparison, expandable activity history, and CSV export
- make report asset links open in a new tab and improve CSV escaping

## Verification
- npm run build completes
- Existing unrelated Rollup warnings remain in notifications and ticket mock data