### PR TITLE
Add purpose badges, MachinePurpose type, and Purpose Manager IT tool

### DIFF
--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -4,6 +4,36 @@ import { Staff } from "./staff";
 
 export const assetStore = writable({});
 
+export type MachinePurpose =
+  | "Student Loan"
+  | "Daily Loaner"
+  | "Staff Spare"
+  | "Staff Tablet"
+  | "MCAS"
+  | "Tech"
+  | "Shelved"
+  | "Printer"
+  | "Phone"
+  | "Security"
+  | "Temp"
+  | "UNKNOWN"
+  | (string & {});
+
+export const ALL_PURPOSES: MachinePurpose[] = [
+  "Student Loan",
+  "Daily Loaner",
+  "Staff Spare",
+  "Staff Tablet",
+  "MCAS",
+  "Tech",
+  "Shelved",
+  "Printer",
+  "Phone",
+  "Security",
+  "Temp",
+  "UNKNOWN",
+];
+
 export type Asset = {
   "Asset Tag": string;
   Category: string;
@@ -13,7 +43,7 @@ export type Asset = {
   "Year of Purchase": string;
   "MAC-Wireless": string;
   _id: string;
-  Purpose: string;
+  Purpose: MachinePurpose;
   "Staff User": string;
   "Email (from Student (Current))": string;
   "YOG (from Student (Current))"; // Ensure YOG is included in the fields

--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -52,7 +52,7 @@ export type Asset = {
   Purpose: MachinePurpose;
   "Staff User": string;
   "Email (from Student (Current))": string;
-  "YOG (from Student (Current))"; // Ensure YOG is included in the fields
+  "YOG (from Student (Current))": string;
   "Student (Current)": string;
   "Device Type": string;
   Location: string;

--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -16,6 +16,8 @@ export type MachinePurpose =
   | "Phone"
   | "Security"
   | "Temp"
+  | "Disposed"
+  | "Retired"
   | "UNKNOWN"
   | (string & {});
 
@@ -31,8 +33,12 @@ export const ALL_PURPOSES: MachinePurpose[] = [
   "Phone",
   "Security",
   "Temp",
+  "Disposed",
+  "Retired",
   "UNKNOWN",
 ];
+
+export const INACTIVE_PURPOSES: MachinePurpose[] = ["Disposed", "Retired"];
 
 export type Asset = {
   "Asset Tag": string;

--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -43,6 +43,7 @@ export const INACTIVE_PURPOSES: MachinePurpose[] = ["Disposed", "Retired"];
 export type Asset = {
   "Asset Tag": string;
   Category: string;
+  Status?: string; // device status, e.g. "Active", "In Repair", "Lost"
   Make: string;
   Model: string;
   Serial: string;

--- a/src/data/invoices.ts
+++ b/src/data/invoices.ts
@@ -5,6 +5,8 @@ export type Invoice = {
   Ticket?: string[];
   "Send Email"?: boolean;
   Student?: string[];
+  Cancellation?: boolean;
+  Note?: string;
 };
 
 export type InvoiceResult = {
@@ -22,6 +24,8 @@ export type InvoiceFields = {
   "Date Created"?: string;
   "Send Email"?: boolean;
   "Email Sent"?: boolean;
+  Cancellation?: boolean;
+  Note?: string;
   "Ticket Block"?: string[];
   "Contact Info"?: string[];
   "Device Asset Tag (from Ticket)"?: string[];

--- a/src/data/lostDeviceBilling.ts
+++ b/src/data/lostDeviceBilling.ts
@@ -1,0 +1,175 @@
+import { get } from "svelte/store";
+import { logger } from "@utils/log";
+import { createTicket, updateTicket, getTicketsForAsset } from "./tickets";
+import type { Ticket } from "./tickets";
+import { createInvoices } from "./invoices";
+import type { InvoiceResult } from "./invoices";
+import type { Asset } from "./inventory";
+import { user } from "./user";
+
+// Default matches the "Full Machine" price in RepairPickList
+export const DEFAULT_REPLACEMENT_COST = 220;
+
+// FormID marker so lost-billing tickets can be found later (e.g. for
+// cancelling the invoice when a device is recovered).
+export const LOST_BILLING_FORM_ID = "lost-device-billing";
+
+function linkedRecordIds(value: unknown): string[] {
+  if (!value) return [];
+  return (Array.isArray(value) ? value : [value]).filter(
+    (id): id is string => typeof id === "string" && id.startsWith("rec")
+  );
+}
+
+// Record ID of the student currently signed out to this asset, if any.
+export function getBillableStudentId(asset: Partial<Asset>): string | null {
+  const ids = linkedRecordIds((asset as any)["Student (Current)"]);
+  return ids[0] || null;
+}
+
+export type LostDeviceBillingResult = {
+  ticket: Ticket;
+  invoices: InvoiceResult[];
+};
+
+/**
+ * Bill the family of the student currently holding `asset` for a lost
+ * device. Creates a Closed ticket (Device Status: Lost) carrying the
+ * replacement cost, then queues an invoice with "Send Email" set so the
+ * existing Airtable automation emails the business office.
+ */
+export async function billForLostDevice(
+  asset: Partial<Asset>,
+  options: { cost?: number; note?: string } = {}
+): Promise<LostDeviceBillingResult> {
+  const cost = options.cost ?? DEFAULT_REPLACEMENT_COST;
+  const studentId = getBillableStudentId(asset);
+  if (!studentId) {
+    throw new Error(
+      `No current student on asset ${asset["Asset Tag"]}; cannot bill for lost device.`
+    );
+  }
+  const userEmail = (get(user) as any)?.email || "system";
+  const description =
+    `Lost device ${asset["Asset Tag"]}: not returned; ` +
+    `billing family for replacement cost ($${cost}).` +
+    (options.note ? ` Note: ${options.note}` : "");
+
+  const historyEntry = {
+    timestamp: new Date().toISOString(),
+    action: "create_ticket",
+    status: "Closed",
+    note: "Created to bill family for lost device",
+    user: userEmail,
+    changes: {
+      "Ticket Status": { to: "Closed" },
+      "Repair Cost": { to: cost },
+    },
+  };
+
+  // Note: the device itself is marked Lost via the signout flow; the
+  // Tickets table has no writable "Device Status" field in Airtable.
+  const ticket = await createTicket({
+    "Ticket Status": "Closed",
+    "Repair Cost": cost,
+    Student: [studentId],
+    Device: [asset._id as string],
+    "User Description": description,
+    SubmittedBy: userEmail,
+    FormID: LOST_BILLING_FORM_ID,
+    History: JSON.stringify({ entries: [historyEntry] }),
+  } as Partial<Ticket>);
+  if ((ticket as any).error) {
+    throw new Error(
+      `Failed to create lost-device ticket for ${asset["Asset Tag"]}: ${
+        (ticket as any).error
+      }`
+    );
+  }
+
+  const invoices = await createInvoices([
+    { Student: [studentId], Ticket: [ticket._id], "Send Email": true },
+  ]);
+  logger.logRegular(
+    "Created lost-device billing ticket and invoice",
+    ticket,
+    invoices
+  );
+  return { ticket, invoices };
+}
+
+/**
+ * Most recent lost-device billing ticket for this asset, or null. Matches
+ * the FormID marker on new tickets, falling back to the description prefix
+ * for tickets created before the marker existed.
+ */
+export async function findLostBillingTicket(
+  assetTag: string
+): Promise<Ticket | null> {
+  const tickets = await getTicketsForAsset(assetTag);
+  const billingTickets = tickets.filter(
+    (t) =>
+      ((t as any).Invoices || []).length &&
+      (t.FormID === LOST_BILLING_FORM_ID ||
+        (t["User Description"] || "").startsWith("Lost device"))
+  );
+  billingTickets.sort((a, b) => (b.Number || 0) - (a.Number || 0));
+  return billingTickets[0] || null;
+}
+
+/**
+ * Queue a cancellation notice for a lost-device invoice after the device
+ * was recovered. Creates an Invoices record linked to the same ticket and
+ * student with the "Cancellation" box checked, so the email automation
+ * tells the business office to cancel (or refund) rather than bill. Also
+ * appends a history entry to the ticket.
+ */
+export async function cancelLostDeviceBilling(
+  ticket: Ticket,
+  options: { note?: string } = {}
+): Promise<InvoiceResult[]> {
+  const userEmail = (get(user) as any)?.email || "system";
+  const note =
+    `Device recovered ${new Date().toLocaleDateString()}; ` +
+    `please cancel the invoice (or refund if already paid).` +
+    (options.note ? ` ${options.note}` : "");
+
+  const invoices = await createInvoices([
+    {
+      Student: ticket.Student,
+      Ticket: [ticket._id],
+      "Send Email": true,
+      Cancellation: true,
+      Note: note,
+    },
+  ]);
+  if ((invoices as any)?.error) {
+    throw new Error(
+      `Failed to create cancellation invoice: ${(invoices as any).error}`
+    );
+  }
+
+  try {
+    let entries = [];
+    try {
+      entries = JSON.parse(ticket.History || "{}").entries || [];
+    } catch (e) {
+      // unparseable history; start fresh rather than fail the cancellation
+    }
+    entries.push({
+      timestamp: new Date().toISOString(),
+      action: "billing_cancellation",
+      status: ticket["Ticket Status"],
+      note,
+      user: userEmail,
+    });
+    await updateTicket(ticket._id, {
+      History: JSON.stringify({ entries }),
+    } as Partial<Ticket>);
+  } catch (e) {
+    // Cancellation went out; a history write failure shouldn't fail the flow
+    logger.logError("Failed to record cancellation on ticket history:", e);
+  }
+  logger.logRegular("Queued lost-device billing cancellation", invoices);
+  return invoices;
+}

--- a/src/data/studentDeviceReport.ts
+++ b/src/data/studentDeviceReport.ts
@@ -23,6 +23,7 @@ export type StudentDeviceReportMachine = {
   serial: string;
   assetTag: string;
   model: string;
+  purpose: string | null;
   lastUsed: string | null;
   lastUser: string;
   status: StudentDeviceMachineStatus;
@@ -427,6 +428,7 @@ export async function buildStudentDeviceReport({
             serial: device.serialNumber,
             assetTag,
             model: asset?.Model || device.model || "",
+            purpose: asset?.Purpose || null,
             lastUsed,
             lastUser: device.recentUsers?.[0]?.email || "",
             asset,

--- a/src/data/studentDeviceReport.ts
+++ b/src/data/studentDeviceReport.ts
@@ -1,4 +1,4 @@
-import type { Asset } from "./inventory";
+import type { Asset, MachinePurpose } from "./inventory";
 import { getAllChromebooks } from "./inventory";
 import { getDevicesForUser, type ChromebookInfo } from "./google";
 import type { Student } from "./students";
@@ -23,7 +23,7 @@ export type StudentDeviceReportMachine = {
   serial: string;
   assetTag: string;
   model: string;
-  purpose: string | null;
+  purpose: MachinePurpose | null;
   lastUsed: string | null;
   lastUser: string;
   status: StudentDeviceMachineStatus;

--- a/src/functions/inventory.ts
+++ b/src/functions/inventory.ts
@@ -115,6 +115,7 @@ export async function handler(event: APIGatewayEvent, context: Context) {
             "Asset Tag",
             "Category",
             "Device Type",
+            "Status",
             "Make",
             "Model",
             "Serial",

--- a/src/functions/invoices.ts
+++ b/src/functions/invoices.ts
@@ -55,6 +55,8 @@ export async function handler(event: APIGatewayEvent, context: Context) {
       "Date Created",
       "Send Email",
       "Email Sent",
+      "Cancellation",
+      "Note",
       "Ticket Block",
       "Contact Info",
       "Device Asset Tag (from Ticket)",

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -129,7 +129,7 @@
     });
     router("/it/purposes/", (ctx) => {
       page = PurposeManager;
-      params = { isIt };
+      params = {};
       title = "Purpose Manager";
     });
     router("/reports/", (ctx) => {
@@ -299,7 +299,9 @@
       <LogIn />
     {:else if page}
       {#key update}
-        <svelte:component this={page} {...params} />
+        <!-- isIt is passed live (not via params) so pages gated on IT
+             access update when the login session resolves after mount -->
+        <svelte:component this={page} {...params} {isIt} />
       {/key}
     {:else}
       Weird, nobody's home

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -110,6 +110,12 @@
       page = Checkout;
       title = "IACS Chromebook Signout";
     });
+    router("/checkout/lost/:tag", (ctx) => {
+      params = { lostTag: ctx.params.tag };
+      page = Checkout;
+      update += 1; // remount so the prefilled tag/status apply
+      title = "IACS Chromebook Signout";
+    });
     router("/history/", (ctx) => {
       page = History;
       title = "IACS Chromebook Signout History";

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -15,6 +15,7 @@
   import { fade } from "svelte/transition";
   import LookupStaff from "@people/staff/LookupStaff.svelte";
   import Reports from "./reports/Reports.svelte";
+  import PurposeManager from "@assets/PurposeManager.svelte";
   import TicketBrowser from "./tickets/TicketBrowser.svelte";
   import TicketNumberPage from "./tickets/TicketNumberPage.svelte";
   import Invoices from "@contracts/Invoices.svelte";
@@ -118,6 +119,11 @@
         mode: "it",
       };
       title = IT_NAME;
+    });
+    router("/it/purposes/", (ctx) => {
+      page = PurposeManager;
+      params = {};
+      title = "Purpose Manager";
     });
     router("/reports/", (ctx) => {
       page = Reports;
@@ -249,6 +255,13 @@
         class:w3-blue={title == IT_NAME}
         href="/it/"
         on:click={l("/it/")}>IT Tool</a
+      >
+      <a
+        class="w3-bar-item w3-button"
+        class:active={page == PurposeManager}
+        class:w3-blue={page == PurposeManager}
+        href="/it/purposes/"
+        on:click={l("/it/purposes/")}>Purpose Manager</a
       >
     {/if}
   </nav>

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -46,6 +46,7 @@
   let params: {
     name?: string;
     tag?: string;
+    isIt?: boolean;
   } = {};
 
   const SIGNOUT_TITLE = "IACS Chromebook Signout";
@@ -122,7 +123,7 @@
     });
     router("/it/purposes/", (ctx) => {
       page = PurposeManager;
-      params = {};
+      params = { isIt };
       title = "Purpose Manager";
     });
     router("/reports/", (ctx) => {

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -2,6 +2,7 @@
   import type { Asset } from "@data/inventory";
   import { l } from "@utils/util";
   import EmailDisplay from "@people/components/EmailDisplay.svelte";
+  import PurposeBadge from "@assets/PurposeBadge.svelte";
   export let asset: Asset | null = null;
   export let showOwner: boolean = false;
   export let openInNewTab: boolean = false;
@@ -37,19 +38,7 @@
         {#if asset["Year of Purchase"]}
           ({asset["Year of Purchase"]})
         {/if}
-        {#if purpose === "MCAS"}
-          <span class="purpose-badge purpose-mcas">MCAS</span>
-        {:else if purpose === "Daily Loaner"}
-          <span class="purpose-badge purpose-daily">DL</span>
-        {:else if purpose === "Staff Spare"}
-          <span class="purpose-badge purpose-spare">Spare</span>
-        {:else if purpose === "Temp"}
-          <span class="purpose-badge purpose-temp">Temp</span>
-        {:else if purpose === "Disposed"}
-          <span class="purpose-badge purpose-retired">Disposed</span>
-        {:else if purpose === "Retired"}
-          <span class="purpose-badge purpose-retired">Retired</span>
-        {/if}
+        <PurposeBadge {purpose} compact={true} />
       </div>
       <div class="limit w3-tiny">
         {#if asset["Charger Type"]}
@@ -123,42 +112,6 @@
   .inactive {
     text-decoration: line-through;
     color: #9e9e9e;
-  }
-  .purpose-badge {
-    display: inline-block;
-    font-size: 10px;
-    font-weight: bold;
-    padding: 1px 4px;
-    border-radius: 3px;
-    vertical-align: middle;
-    margin-left: 4px;
-    letter-spacing: 0.03em;
-  }
-  .purpose-mcas {
-    background: #111;
-    color: #ff4444;
-    border: 1px solid #ff4444;
-  }
-  .purpose-daily {
-    background: #e3f2fd;
-    color: #0d47a1;
-    border: 1px solid #90caf9;
-  }
-  .purpose-spare {
-    background: #fff3e0;
-    color: #bf360c;
-    border: 1px solid #ffcc80;
-  }
-  .purpose-temp {
-    background: #f5f5f5;
-    color: #616161;
-    border: 1px solid #bdbdbd;
-  }
-  .purpose-retired {
-    background: #eeeeee;
-    color: #9e9e9e;
-    border: 1px solid #bdbdbd;
-    text-decoration: line-through;
   }
   .retired {
     opacity: 0.5;

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -6,6 +6,7 @@
   export let showOwner: boolean = false;
   export let openInNewTab: boolean = false;
   $: assetTag = (asset && asset["Asset Tag"]) || "";
+  $: purpose = asset?.Purpose || null;
 </script>
 
 {#if !asset || !assetTag}
@@ -33,6 +34,13 @@
         <b>{asset.Make || ""} {asset.Model || ""}</b>
         {#if asset["Year of Purchase"]}
           ({asset["Year of Purchase"]})
+        {/if}
+        {#if purpose === "MCAS"}
+          <span class="purpose-badge purpose-mcas">MCAS</span>
+        {:else if purpose === "Daily Loaner"}
+          <span class="purpose-badge purpose-daily">DL</span>
+        {:else if purpose === "Staff Spare"}
+          <span class="purpose-badge purpose-spare">Spare</span>
         {/if}
       </div>
       <div class="limit w3-tiny">
@@ -107,5 +115,30 @@
   .inactive {
     text-decoration: line-through;
     color: #9e9e9e;
+  }
+  .purpose-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 1px 4px;
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-left: 4px;
+    letter-spacing: 0.03em;
+  }
+  .purpose-mcas {
+    background: #111;
+    color: #ff4444;
+    border: 1px solid #ff4444;
+  }
+  .purpose-daily {
+    background: #e3f2fd;
+    color: #0d47a1;
+    border: 1px solid #90caf9;
+  }
+  .purpose-spare {
+    background: #fff3e0;
+    color: #bf360c;
+    border: 1px solid #ffcc80;
   }
 </style>

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -41,6 +41,8 @@
           <span class="purpose-badge purpose-daily">DL</span>
         {:else if purpose === "Staff Spare"}
           <span class="purpose-badge purpose-spare">Spare</span>
+        {:else if purpose === "Temp"}
+          <span class="purpose-badge purpose-temp">Temp</span>
         {/if}
       </div>
       <div class="limit w3-tiny">
@@ -140,5 +142,10 @@
     background: #fff3e0;
     color: #bf360c;
     border: 1px solid #ffcc80;
+  }
+  .purpose-temp {
+    background: #f5f5f5;
+    color: #616161;
+    border: 1px solid #bdbdbd;
   }
 </style>

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -9,6 +9,7 @@
   $: assetTag = (asset && asset["Asset Tag"]) || "";
   $: purpose = asset?.Purpose || null;
   $: isRetired = purpose === "Disposed" || purpose === "Retired";
+  $: isLost = asset?.Status === "Lost";
 </script>
 
 {#if !asset || !assetTag}
@@ -39,6 +40,9 @@
           ({asset["Year of Purchase"]})
         {/if}
         <PurposeBadge {purpose} compact={true} />
+        {#if isLost}
+          <span class="w3-tag w3-red w3-round lost-badge">LOST</span>
+        {/if}
       </div>
       <div class="limit w3-tiny">
         {#if asset["Charger Type"]}
@@ -54,7 +58,7 @@
       {#if showOwner}
         <div class="w3-small">
           {#if asset["Email (from Student (Current))"]}
-            Currently signed out to
+            {isLost ? "Lost — last signed out to" : "Currently signed out to"}
             <b class:inactive={asset["Student Status"]?.[0] === "Inactive"}>
               <EmailDisplay email={asset["Email (from Student (Current))"]} />
             </b>
@@ -119,5 +123,10 @@
   .tag-retired {
     border: 2px dashed currentColor !important;
     background: transparent !important;
+  }
+  .lost-badge {
+    font-size: 0.8em;
+    font-weight: bold;
+    margin-left: 4px;
   }
 </style>

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -7,17 +7,19 @@
   export let openInNewTab: boolean = false;
   $: assetTag = (asset && asset["Asset Tag"]) || "";
   $: purpose = asset?.Purpose || null;
+  $: isRetired = purpose === "Disposed" || purpose === "Retired";
 </script>
 
 {#if !asset || !assetTag}
   <div class="w3-small w3-text-gray">(Unknown Asset)</div>
 {:else}
-  <div class="w3-container row">
+  <div class="w3-container row" class:retired={isRetired}>
     <div
       class="tag w3-round-xlarge"
       class:w3-indigo={/^[0-9][0-9][0-9][0-9]$/.test(assetTag)}
       class:w3-red={/^A[0-9][0-9][0-9][0-9]/.test(assetTag)}
       class:w3-black={/^[0-9][0-9][0-9]$/.test(assetTag)}
+      class:tag-retired={isRetired}
     >
       {#if openInNewTab}
         <a href={`/asset/${assetTag}`} target="_blank" rel="noreferrer"
@@ -43,6 +45,10 @@
           <span class="purpose-badge purpose-spare">Spare</span>
         {:else if purpose === "Temp"}
           <span class="purpose-badge purpose-temp">Temp</span>
+        {:else if purpose === "Disposed"}
+          <span class="purpose-badge purpose-retired">Disposed</span>
+        {:else if purpose === "Retired"}
+          <span class="purpose-badge purpose-retired">Retired</span>
         {/if}
       </div>
       <div class="limit w3-tiny">
@@ -147,5 +153,18 @@
     background: #f5f5f5;
     color: #616161;
     border: 1px solid #bdbdbd;
+  }
+  .purpose-retired {
+    background: #eeeeee;
+    color: #9e9e9e;
+    border: 1px solid #bdbdbd;
+    text-decoration: line-through;
+  }
+  .retired {
+    opacity: 0.5;
+  }
+  .tag-retired {
+    border: 2px dashed currentColor !important;
+    background: transparent !important;
   }
 </style>

--- a/src/ui/assets/Checkout.svelte
+++ b/src/ui/assets/Checkout.svelte
@@ -12,7 +12,7 @@
   import SimpleForm from "@components/SimpleForm.svelte";
   import type { Student } from "@data/students";
   import type { Staff } from "@data/staff";
-  import { getCurrentLoansForStudent } from "@data/inventory";
+  import { getCurrentLoansForStudent, updateAsset } from "@data/inventory";
   import type { Asset } from "@data/inventory";
   import { l, withLoadingIndicator } from "@utils/util";
   import type { CheckoutStatus } from "@data/signout";
@@ -41,6 +41,19 @@
   import CheckoutTicketLink from "@ui/tickets/components/CheckoutTicketLink.svelte";
   import { logger } from "@utils/log";
   import Loader from "@components/Loader.svelte";
+  import {
+    billForLostDevice,
+    getBillableStudentId,
+    findLostBillingTicket,
+    cancelLostDeviceBilling,
+    DEFAULT_REPLACEMENT_COST,
+  } from "@data/lostDeviceBilling";
+  import { showToast } from "@components/toastStore";
+
+  // Set via the /checkout/lost/:tag route to land here with the asset
+  // pre-filled and "Mark as Lost" selected (e.g. from student lookup).
+  export let lostTag: string = "";
+
   let status: CheckoutStatus = "Out";
   let notes = "";
   let studentNotes = "";
@@ -59,6 +72,10 @@
   });
 
   onMount(async () => {
+    if (lostTag) {
+      $assetTags = [lostTag];
+      status = "Lost";
+    }
     logger.logVerbose("Fetch contacts!");
     await getContacts();
     logger.logVerbose($contactStore);
@@ -177,18 +194,134 @@
     }
   }
 
+  let billLostReplacement = false;
+  let lostReplacementCost = DEFAULT_REPLACEMENT_COST;
+
+  function currentStudentEmail(asset) {
+    const email = asset && asset["Email (from Student (Current))"];
+    return (Array.isArray(email) ? email.join(", ") : email) || "";
+  }
+
+  // --- Recovery: checking in a device that was marked Lost ---
+  let cancelLostBilling = true;
+  let lostBillingTickets = {}; // asset tag -> Ticket | null (null = none found)
+  let lostBillingLookups = new Set();
+
+  $: returnedLostAssets =
+    (status == "Returned" &&
+      (assets || []).filter((a) => a && a.Status === "Lost")) ||
+    [];
+  $: if (status == "Returned") lookupLostBillingTickets(assets);
+
+  async function lookupLostBillingTickets(assets) {
+    for (let asset of assets || []) {
+      if (!asset || asset.Status !== "Lost") continue;
+      const tag = asset["Asset Tag"];
+      if (lostBillingLookups.has(tag)) continue;
+      lostBillingLookups.add(tag);
+      try {
+        const ticket = await findLostBillingTicket(tag);
+        lostBillingTickets = { ...lostBillingTickets, [tag]: ticket };
+      } catch (e) {
+        logger.logError("Failed to look up lost-billing ticket:", e);
+        lostBillingLookups.delete(tag); // allow retry
+      }
+    }
+  }
+  $: billableLostAssets = (assets || []).filter(
+    (asset) => asset && getBillableStudentId(asset)
+  );
+
+  async function billLostAsset(asset) {
+    $checkoutStatus = `Sending invoice for ${asset["Asset Tag"]}`;
+    try {
+      const { ticket } = await billForLostDevice(asset, {
+        cost: lostReplacementCost,
+        note: notes,
+      });
+      showToast(
+        `Asked business office to invoice family for ${asset["Asset Tag"]}`,
+        "success"
+      );
+      return ticket;
+    } catch (e) {
+      logger.logError("Lost-device billing failed:", e);
+      showToast(`Invoice failed for ${asset["Asset Tag"]}: ${e.message}`, "error");
+      return null;
+    } finally {
+      $checkoutStatus = "";
+    }
+  }
+
   async function checkOut() {
     getNote();
     logger.logVerbose("Updated note:", notes);
     let success: boolean = false;
     let verb = statusToVerb[status] || "Updating";
+    let billing = status == "Lost" && billLostReplacement;
     if (assets) {
       let count = 0;
       for (let asset of assets) {
         count++;
+        // Bill first so the signout note can record the ticket number.
+        let assetNotes = notes;
+        if (billing && asset) {
+          if (getBillableStudentId(asset)) {
+            const ticket = await billLostAsset(asset);
+            if (ticket) {
+              assetNotes =
+                (notes ? notes + " " : "") +
+                `Billed family $${lostReplacementCost} for replacement` +
+                (ticket.Number ? ` (Ticket #${ticket.Number}).` : ".");
+            }
+          } else {
+            showToast(
+              `${asset["Asset Tag"]}: no current student, so no invoice was sent`,
+              "info"
+            );
+          }
+        }
+        // Recovered lost device: queue an invoice cancellation notice
+        if (
+          status == "Returned" &&
+          cancelLostBilling &&
+          asset?.Status === "Lost" &&
+          lostBillingTickets[asset["Asset Tag"]]
+        ) {
+          const billingTicket = lostBillingTickets[asset["Asset Tag"]];
+          $checkoutStatus = `Sending cancellation for ${asset["Asset Tag"]}`;
+          try {
+            await cancelLostDeviceBilling(billingTicket, { note: notes });
+            assetNotes =
+              (notes ? notes + " " : "") +
+              `Recovered — billing cancellation sent (Ticket #${billingTicket.Number}).`;
+            showToast(
+              `Asked business office to cancel invoice for ${asset["Asset Tag"]}`,
+              "success"
+            );
+          } catch (e) {
+            logger.logError("Billing cancellation failed:", e);
+            showToast(
+              `Cancellation failed for ${asset["Asset Tag"]}: ${e.message}`,
+              "error"
+            );
+          }
+          $checkoutStatus = "";
+        }
         $checkoutStatus = `${verb} ${count} of ${assets.length}`;
-        success = await doCheckout(asset, notes, daily);
+        success = await doCheckout(asset, assetNotes, daily);
         $checkoutStatus = "";
+        if (success && asset) {
+          if (status == "Lost") {
+            await updateAsset(asset._id, { Status: "Lost" });
+          } else if (
+            (status == "Out" || status == "Returned") &&
+            asset.Status == "Lost"
+          ) {
+            // Lost device turned up again — clear the Lost flag
+            await updateAsset(asset._id, { Status: "Active" });
+          }
+        }
       }
     }
     /* if (charger) {
@@ -204,6 +337,7 @@
       $studentName = "";
       $assetTags = [];
       notes = "";
+      billLostReplacement = false;
       $screenNote = null;
       $keyboardNote = null;
       $powerNote = null;
@@ -504,6 +638,80 @@ Hinge bolts:New screws needed for display hinges*/
             {/if}
           </div>
         {/each}
+      </div>
+    {/if}
+    {#if status == "Lost"}
+      <div in:fly|local={{ y: -30 }} out:fade|local class="row">
+        <FormField name="Billing">
+          <label class:bold={billLostReplacement}>
+            <input type="checkbox" bind:checked={billLostReplacement} />
+            Bill family for replacement
+          </label>
+          {#if billLostReplacement}
+            <label style="margin-left: 16px;">
+              Replacement cost ($):
+              <input
+                type="number"
+                min="0"
+                bind:value={lostReplacementCost}
+                class="w3-input w3-border"
+                style="width: 7em; display: inline-block; margin-left: 8px;"
+              />
+            </label>
+            <div class="w3-small w3-text-gray" style="margin-top: 4px;">
+              {#if billableLostAssets.length}
+                We'll create a closed "Lost" ticket and ask the business office
+                to invoice
+                {billableLostAssets
+                  .map(
+                    (a) =>
+                      `${currentStudentEmail(a) || "the current student"} for ${
+                        a["Asset Tag"]
+                      }`
+                  )
+                  .join("; ")}.
+              {:else}
+                None of these devices have a current student, so there is no
+                one to invoice. Sign the device out to the student first if you
+                need to bill them.
+              {/if}
+            </div>
+          {/if}
+        </FormField>
+      </div>
+    {/if}
+    {#if status == "Returned" && returnedLostAssets.length}
+      <div in:fly|local={{ y: -30 }} out:fade|local class="row">
+        <FormField name="Recovery">
+          <div>
+            {#each returnedLostAssets as asset (asset["Asset Tag"])}
+              {#if lostBillingTickets[asset["Asset Tag"]] === undefined}
+                <div class="w3-small w3-text-gray">
+                  {asset["Asset Tag"]} was marked lost — checking for invoices…
+                </div>
+              {:else if lostBillingTickets[asset["Asset Tag"]]}
+                <div class="w3-small">
+                  <b>{asset["Asset Tag"]}</b> was marked lost and the family was
+                  billed ${lostBillingTickets[asset["Asset Tag"]][
+                    "Repair Cost"
+                  ] || "?"} (Ticket #{lostBillingTickets[asset["Asset Tag"]]
+                    .Number}).
+                </div>
+              {:else}
+                <div class="w3-small w3-text-gray">
+                  {asset["Asset Tag"]} was marked lost; no invoice found, so
+                  it will simply be checked back in.
+                </div>
+              {/if}
+            {/each}
+            {#if returnedLostAssets.some((a) => lostBillingTickets[a["Asset Tag"]])}
+              <label class:bold={cancelLostBilling}>
+                <input type="checkbox" bind:checked={cancelLostBilling} />
+                Ask business office to cancel the invoice
+              </label>
+            {/if}
+          </div>
+        </FormField>
       </div>
     {/if}
     {#if status == "Returned"}

--- a/src/ui/assets/PurposeBadge.svelte
+++ b/src/ui/assets/PurposeBadge.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type { MachinePurpose } from "@data/inventory";
+  export let purpose: MachinePurpose | string | null | undefined = null;
+  // compact: abbreviate text for tight spaces (AssetDisplay inline badge)
+  export let compact = false;
+  // showFallback: render plain text for purposes that have no styled badge
+  export let showFallback = false;
+
+  const LABELS: Partial<Record<string, string>> = {
+    "Daily Loaner": "DL",
+    "Staff Spare": "Spare",
+  };
+
+  const STYLED = new Set(["MCAS", "Daily Loaner", "Staff Spare", "Temp", "Disposed", "Retired"]);
+
+  $: label = compact
+    ? (LABELS[purpose ?? ""] ?? purpose ?? "")
+    : (purpose ?? "");
+  $: hasStyledBadge = STYLED.has(purpose ?? "");
+</script>
+
+{#if purpose === "MCAS"}
+  <span class="purpose-badge purpose-mcas">{label}</span>
+{:else if purpose === "Daily Loaner"}
+  <span class="purpose-badge purpose-daily">{label}</span>
+{:else if purpose === "Staff Spare"}
+  <span class="purpose-badge purpose-spare">{label}</span>
+{:else if purpose === "Temp"}
+  <span class="purpose-badge purpose-temp">{label}</span>
+{:else if purpose === "Disposed" || purpose === "Retired"}
+  <span class="purpose-badge purpose-retired">{label}</span>
+{:else if showFallback && purpose}
+  {purpose}
+{/if}
+
+<style>
+  .purpose-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 1px 4px;
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-left: 4px;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .purpose-mcas {
+    background: #111;
+    color: #ff4444;
+    border: 1px solid #ff4444;
+  }
+  .purpose-daily {
+    background: #e3f2fd;
+    color: #0d47a1;
+    border: 1px solid #90caf9;
+  }
+  .purpose-spare {
+    background: #fff3e0;
+    color: #bf360c;
+    border: 1px solid #ffcc80;
+  }
+  .purpose-temp {
+    background: #f5f5f5;
+    color: #616161;
+    border: 1px solid #bdbdbd;
+  }
+  .purpose-retired {
+    background: #eeeeee;
+    color: #9e9e9e;
+    border: 1px solid #bdbdbd;
+    text-decoration: line-through;
+  }
+</style>

--- a/src/ui/assets/PurposeManager.svelte
+++ b/src/ui/assets/PurposeManager.svelte
@@ -1,0 +1,314 @@
+<script lang="ts">
+  import {
+    getAllChromebooks,
+    updateAsset,
+    ALL_PURPOSES,
+    type Asset,
+    type MachinePurpose,
+  } from "@data/inventory";
+  import AssetDisplay from "@assets/AssetDisplay.svelte";
+  import Loader from "@components/Loader.svelte";
+  import { logger } from "@utils/log";
+
+  let assets: Asset[] = [];
+  let loading = false;
+  let loadError = "";
+
+  let filterPurpose = "";
+  let filterModel = "";
+  let selectedIds = new Set<string>();
+
+  let targetPurpose: MachinePurpose = "Student Loan";
+  let updating = false;
+  let updateResult: { succeeded: number; failed: number } | null = null;
+
+  $: uniqueModels = [...new Set(assets.map((a) => a.Model).filter(Boolean))].sort();
+
+  $: filtered = assets.filter((a) => {
+    if (filterPurpose && a.Purpose !== filterPurpose) return false;
+    if (filterModel && a.Model !== filterModel) return false;
+    return true;
+  });
+
+  $: allFilteredSelected =
+    filtered.length > 0 && filtered.every((a) => selectedIds.has(a._id));
+
+  async function load() {
+    loading = true;
+    loadError = "";
+    selectedIds = new Set();
+    updateResult = null;
+    try {
+      const raw = await getAllChromebooks();
+      assets = (raw || []).map((r) => ({ ...r.fields, _id: r.id }));
+    } catch (err) {
+      loadError = err instanceof Error ? err.message : String(err);
+      logger.logError("PurposeManager load failed", err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggleSelect(id: string) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    selectedIds = next;
+  }
+
+  function toggleSelectAll() {
+    if (allFilteredSelected) {
+      const next = new Set(selectedIds);
+      for (const a of filtered) next.delete(a._id);
+      selectedIds = next;
+    } else {
+      const next = new Set(selectedIds);
+      for (const a of filtered) next.add(a._id);
+      selectedIds = next;
+    }
+  }
+
+  function clearFilters() {
+    filterPurpose = "";
+    filterModel = "";
+  }
+
+  async function applyPurpose() {
+    const targets = assets.filter((a) => selectedIds.has(a._id));
+    if (!targets.length) return;
+    updating = true;
+    updateResult = null;
+    let succeeded = 0;
+    let failed = 0;
+
+    await Promise.allSettled(
+      targets.map(async (asset) => {
+        try {
+          await updateAsset(asset._id, { Purpose: targetPurpose });
+          asset.Purpose = targetPurpose;
+          succeeded += 1;
+        } catch (err) {
+          logger.logError("PurposeManager update failed for", asset["Asset Tag"], err);
+          failed += 1;
+        }
+      }),
+    );
+
+    assets = [...assets];
+    selectedIds = new Set();
+    updateResult = { succeeded, failed };
+    updating = false;
+  }
+</script>
+
+<section class="purpose-manager">
+  <h2>Purpose Manager</h2>
+  <p class="w3-text-gray">
+    Load all Chromebooks, filter by current purpose or model, select machines,
+    then bulk-update their purpose.
+  </p>
+
+  <div class="toolbar">
+    <button class="w3-button w3-blue" on:click={load} disabled={loading}>
+      {assets.length ? "Reload" : "Load Chromebooks"}
+    </button>
+
+    {#if assets.length}
+      <label>
+        Filter purpose
+        <select class="w3-select w3-border" bind:value={filterPurpose}>
+          <option value="">All</option>
+          {#each ALL_PURPOSES as p}
+            <option value={p}>{p}</option>
+          {/each}
+        </select>
+      </label>
+
+      <label>
+        Filter model
+        <select class="w3-select w3-border" bind:value={filterModel}>
+          <option value="">All</option>
+          {#each uniqueModels as m}
+            <option value={m}>{m}</option>
+          {/each}
+        </select>
+      </label>
+
+      {#if filterPurpose || filterModel}
+        <button class="w3-button w3-border" on:click={clearFilters}>
+          Clear filters
+        </button>
+      {/if}
+    {/if}
+  </div>
+
+  {#if loading}
+    <Loader working={true} text="Loading Chromebooks…" />
+  {:else if loadError}
+    <div class="w3-panel w3-pale-red w3-border">{loadError}</div>
+  {:else if assets.length}
+    <div class="summary-bar">
+      <span>{filtered.length} shown</span>
+      <span>{selectedIds.size} selected</span>
+      {#if selectedIds.size}
+        <button
+          class="w3-button w3-tiny w3-border"
+          on:click={() => (selectedIds = new Set())}>Deselect all</button
+        >
+      {/if}
+    </div>
+
+    {#if selectedIds.size}
+      <div class="apply-bar w3-panel w3-pale-blue w3-border">
+        <strong>Set {selectedIds.size} machine{selectedIds.size === 1 ? "" : "s"} to:</strong>
+        <select class="w3-select w3-border" bind:value={targetPurpose}>
+          {#each ALL_PURPOSES as p}
+            <option value={p}>{p}</option>
+          {/each}
+        </select>
+        <button
+          class="w3-button w3-green"
+          disabled={updating}
+          on:click={applyPurpose}
+        >
+          {updating ? "Updating…" : "Apply"}
+        </button>
+      </div>
+    {/if}
+
+    {#if updateResult}
+      <div
+        class="w3-panel w3-border"
+        class:w3-pale-green={updateResult.failed === 0}
+        class:w3-pale-red={updateResult.failed > 0}
+      >
+        {updateResult.succeeded} updated
+        {#if updateResult.failed}
+          · {updateResult.failed} failed
+        {/if}
+      </div>
+    {/if}
+
+    <div class="table-wrap">
+      <table class="w3-table w3-bordered w3-striped">
+        <thead>
+          <tr>
+            <th class="check-col">
+              <input
+                type="checkbox"
+                checked={allFilteredSelected}
+                on:change={toggleSelectAll}
+                title="Select/deselect all visible"
+              />
+            </th>
+            <th>Asset</th>
+            <th>Current Purpose</th>
+            <th>Year</th>
+            <th>Current User</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each filtered as asset (asset._id)}
+            <tr class:selected={selectedIds.has(asset._id)}>
+              <td class="check-col">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(asset._id)}
+                  on:change={() => toggleSelect(asset._id)}
+                />
+              </td>
+              <td><AssetDisplay {asset} openInNewTab={true} /></td>
+              <td>
+                {#if asset.Purpose === "MCAS"}
+                  <span class="purpose-badge purpose-mcas">MCAS</span>
+                {:else if asset.Purpose === "Daily Loaner"}
+                  <span class="purpose-badge purpose-daily">Daily Loaner</span>
+                {:else if asset.Purpose === "Staff Spare"}
+                  <span class="purpose-badge purpose-spare">Staff Spare</span>
+                {:else}
+                  {asset.Purpose || "—"}
+                {/if}
+              </td>
+              <td class="w3-small">{asset["Year of Purchase"] || "—"}</td>
+              <td class="w3-small">
+                {asset["Email (from Student (Current))"] ||
+                  asset["Staff User"] ||
+                  "—"}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .purpose-manager {
+    padding: 16px;
+  }
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+    margin-bottom: 12px;
+  }
+  .toolbar label {
+    font-weight: bold;
+    min-width: 140px;
+  }
+  .summary-bar {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    font-size: 13px;
+    margin-bottom: 8px;
+    color: #555;
+  }
+  .apply-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+  .apply-bar select {
+    min-width: 160px;
+  }
+  .table-wrap {
+    overflow-x: auto;
+  }
+  .check-col {
+    width: 36px;
+    text-align: center;
+  }
+  tr.selected {
+    background: #e8f5e9 !important;
+  }
+  .purpose-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+  .purpose-mcas {
+    background: #111;
+    color: #ff4444;
+    border: 1px solid #ff4444;
+  }
+  .purpose-daily {
+    background: #e3f2fd;
+    color: #0d47a1;
+    border: 1px solid #90caf9;
+  }
+  .purpose-spare {
+    background: #fff3e0;
+    color: #bf360c;
+    border: 1px solid #ffcc80;
+  }
+</style>

--- a/src/ui/assets/PurposeManager.svelte
+++ b/src/ui/assets/PurposeManager.svelte
@@ -9,8 +9,11 @@
     type MachinePurpose,
   } from "@data/inventory";
   import AssetDisplay from "@assets/AssetDisplay.svelte";
+  import PurposeBadge from "@assets/PurposeBadge.svelte";
   import Loader from "@components/Loader.svelte";
   import { logger } from "@utils/log";
+
+  export let isIt = false;
 
   type LoadMode = "purpose" | "tags" | "all";
 
@@ -132,8 +135,11 @@
     let succeeded = 0;
     let failed = 0;
 
-    await Promise.allSettled(
-      targets.map(async (asset) => {
+    const CONCURRENCY = 5;
+    let nextIndex = 0;
+    const workers = Array.from({ length: Math.min(CONCURRENCY, targets.length) }, async () => {
+      while (nextIndex < targets.length) {
+        const asset = targets[nextIndex++];
         try {
           await updateAsset(asset._id, { Purpose: targetPurpose });
           asset.Purpose = targetPurpose;
@@ -142,8 +148,9 @@
           logger.logError("PurposeManager update failed for", asset["Asset Tag"], err);
           failed += 1;
         }
-      }),
-    );
+      }
+    });
+    await Promise.all(workers);
 
     assets = [...assets];
     selectedIds = new Set();
@@ -153,6 +160,11 @@
 </script>
 
 <section class="purpose-manager">
+  {#if !isIt}
+    <div class="w3-panel w3-pale-red w3-border">
+      Access denied. This tool is for IT staff only.
+    </div>
+  {:else}
   <h2>Purpose Manager</h2>
 
   <div class="load-panel w3-panel w3-light-grey w3-border">
@@ -312,17 +324,8 @@
               </td>
               <td><AssetDisplay {asset} openInNewTab={true} /></td>
               <td>
-                {#if asset.Purpose === "MCAS"}
-                  <span class="purpose-badge purpose-mcas">MCAS</span>
-                {:else if asset.Purpose === "Daily Loaner"}
-                  <span class="purpose-badge purpose-daily">Daily Loaner</span>
-                {:else if asset.Purpose === "Staff Spare"}
-                  <span class="purpose-badge purpose-spare">Staff Spare</span>
-                {:else if asset.Purpose === "Temp"}
-                  <span class="purpose-badge purpose-temp">Temp</span>
-                {:else}
-                  {asset.Purpose || "—"}
-                {/if}
+                <PurposeBadge purpose={asset.Purpose} showFallback={true} />
+                {#if !asset.Purpose}—{/if}
               </td>
               <td class="w3-small">{asset["Year of Purchase"] || "—"}</td>
               <td class="w3-small">
@@ -335,6 +338,7 @@
         </tbody>
       </table>
     </div>
+  {/if}
   {/if}
 </section>
 
@@ -410,32 +414,5 @@
   }
   tr.selected {
     background: #e8f5e9 !important;
-  }
-  .purpose-badge {
-    display: inline-block;
-    font-size: 11px;
-    font-weight: bold;
-    padding: 2px 6px;
-    border-radius: 3px;
-  }
-  .purpose-mcas {
-    background: #111;
-    color: #ff4444;
-    border: 1px solid #ff4444;
-  }
-  .purpose-daily {
-    background: #e3f2fd;
-    color: #0d47a1;
-    border: 1px solid #90caf9;
-  }
-  .purpose-spare {
-    background: #fff3e0;
-    color: #bf360c;
-    border: 1px solid #ffcc80;
-  }
-  .purpose-temp {
-    background: #f5f5f5;
-    color: #616161;
-    border: 1px solid #bdbdbd;
   }
 </style>

--- a/src/ui/assets/PurposeManager.svelte
+++ b/src/ui/assets/PurposeManager.svelte
@@ -318,6 +318,8 @@
                   <span class="purpose-badge purpose-daily">Daily Loaner</span>
                 {:else if asset.Purpose === "Staff Spare"}
                   <span class="purpose-badge purpose-spare">Staff Spare</span>
+                {:else if asset.Purpose === "Temp"}
+                  <span class="purpose-badge purpose-temp">Temp</span>
                 {:else}
                   {asset.Purpose || "—"}
                 {/if}
@@ -430,5 +432,10 @@
     background: #fff3e0;
     color: #bf360c;
     border: 1px solid #ffcc80;
+  }
+  .purpose-temp {
+    background: #f5f5f5;
+    color: #616161;
+    border: 1px solid #bdbdbd;
   }
 </style>

--- a/src/ui/assets/PurposeManager.svelte
+++ b/src/ui/assets/PurposeManager.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import {
+    fetchReport,
+    searchForAsset,
     getAllChromebooks,
     updateAsset,
     ALL_PURPOSES,
@@ -10,11 +12,17 @@
   import Loader from "@components/Loader.svelte";
   import { logger } from "@utils/log";
 
+  type LoadMode = "purpose" | "tags" | "all";
+
+  let loadMode: LoadMode = "purpose";
+  let loadPurpose: MachinePurpose = "MCAS";
+  let tagInput = "";
+
   let assets: Asset[] = [];
   let loading = false;
   let loadError = "";
+  let notFoundTags: string[] = [];
 
-  let filterPurpose = "";
   let filterModel = "";
   let selectedIds = new Set<string>();
 
@@ -25,7 +33,6 @@
   $: uniqueModels = [...new Set(assets.map((a) => a.Model).filter(Boolean))].sort();
 
   $: filtered = assets.filter((a) => {
-    if (filterPurpose && a.Purpose !== filterPurpose) return false;
     if (filterModel && a.Model !== filterModel) return false;
     return true;
   });
@@ -33,14 +40,60 @@
   $: allFilteredSelected =
     filtered.length > 0 && filtered.every((a) => selectedIds.has(a._id));
 
+  function parseTags(value: string): string[] {
+    return value
+      .split(/[\n\r,;\t ]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  function normalizeRecord(r: any): Asset {
+    return { ...r.fields, _id: r.id };
+  }
+
   async function load() {
     loading = true;
     loadError = "";
+    notFoundTags = [];
     selectedIds = new Set();
     updateResult = null;
+    assets = [];
+
     try {
-      const raw = await getAllChromebooks();
-      assets = (raw || []).map((r) => ({ ...r.fields, _id: r.id }));
+      if (loadMode === "purpose") {
+        const raw = await fetchReport({ chromebookOnly: true, purpose: loadPurpose });
+        assets = (raw || []).map(normalizeRecord);
+      } else if (loadMode === "tags") {
+        const tags = parseTags(tagInput);
+        if (!tags.length) {
+          loadError = "Paste at least one asset tag.";
+          return;
+        }
+        const results = await Promise.all(tags.map((tag) => searchForAsset(tag)));
+        const found: Asset[] = [];
+        const missing: string[] = [];
+        tags.forEach((tag, i) => {
+          const hits = results[i];
+          if (hits && hits.length) {
+            found.push(...hits.map(normalizeRecord));
+          } else {
+            missing.push(tag);
+          }
+        });
+        // Deduplicate by _id
+        const seen = new Set<string>();
+        assets = found.filter((a) => {
+          if (seen.has(a._id)) return false;
+          seen.add(a._id);
+          return true;
+        });
+        notFoundTags = missing;
+        // Auto-select all found when loading by tag list
+        selectedIds = new Set(assets.map((a) => a._id));
+      } else {
+        const raw = await getAllChromebooks();
+        assets = (raw || []).map(normalizeRecord);
+      }
     } catch (err) {
       loadError = err instanceof Error ? err.message : String(err);
       logger.logError("PurposeManager load failed", err);
@@ -69,11 +122,6 @@
       for (const a of filtered) next.add(a._id);
       selectedIds = next;
     }
-  }
-
-  function clearFilters() {
-    filterPurpose = "";
-    filterModel = "";
   }
 
   async function applyPurpose() {
@@ -106,53 +154,95 @@
 
 <section class="purpose-manager">
   <h2>Purpose Manager</h2>
-  <p class="w3-text-gray">
-    Load all Chromebooks, filter by current purpose or model, select machines,
-    then bulk-update their purpose.
-  </p>
 
-  <div class="toolbar">
-    <button class="w3-button w3-blue" on:click={load} disabled={loading}>
-      {assets.length ? "Reload" : "Load Chromebooks"}
-    </button>
-
-    {#if assets.length}
-      <label>
-        Filter purpose
-        <select class="w3-select w3-border" bind:value={filterPurpose}>
-          <option value="">All</option>
-          {#each ALL_PURPOSES as p}
-            <option value={p}>{p}</option>
-          {/each}
-        </select>
+  <div class="load-panel w3-panel w3-light-grey w3-border">
+    <div class="mode-row">
+      <label class="mode-option">
+        <input type="radio" bind:group={loadMode} value="purpose" />
+        By current purpose
       </label>
-
-      <label>
-        Filter model
-        <select class="w3-select w3-border" bind:value={filterModel}>
-          <option value="">All</option>
-          {#each uniqueModels as m}
-            <option value={m}>{m}</option>
-          {/each}
-        </select>
+      <label class="mode-option">
+        <input type="radio" bind:group={loadMode} value="tags" />
+        By asset tags
       </label>
+      <label class="mode-option">
+        <input type="radio" bind:group={loadMode} value="all" />
+        All Chromebooks
+      </label>
+    </div>
 
-      {#if filterPurpose || filterModel}
-        <button class="w3-button w3-border" on:click={clearFilters}>
-          Clear filters
+    {#if loadMode === "purpose"}
+      <div class="mode-controls">
+        <label>
+          Purpose to load
+          <select class="w3-select w3-border" bind:value={loadPurpose}>
+            {#each ALL_PURPOSES as p}
+              <option value={p}>{p}</option>
+            {/each}
+          </select>
+        </label>
+        <button class="w3-button w3-blue" on:click={load} disabled={loading}>
+          Load {loadPurpose} machines
         </button>
-      {/if}
+      </div>
+    {:else if loadMode === "tags"}
+      <div class="mode-controls">
+        <label class="tag-label">
+          Asset tags (one per line, or comma/space separated)
+          <textarea
+            class="w3-input w3-border tag-input"
+            rows="4"
+            bind:value={tagInput}
+            placeholder="1234&#10;A5678&#10;..."
+          ></textarea>
+        </label>
+        <button
+          class="w3-button w3-blue"
+          on:click={load}
+          disabled={loading || !tagInput.trim()}
+        >
+          Load {parseTags(tagInput).length || ""} tags
+        </button>
+      </div>
+    {:else}
+      <div class="mode-controls">
+        <p class="w3-text-gray w3-small">
+          Loads every Chromebook in inventory — may be slow.
+        </p>
+        <button class="w3-button w3-blue" on:click={load} disabled={loading}>
+          Load all Chromebooks
+        </button>
+      </div>
     {/if}
   </div>
 
   {#if loading}
-    <Loader working={true} text="Loading Chromebooks…" />
+    <Loader working={true} text="Loading…" />
   {:else if loadError}
     <div class="w3-panel w3-pale-red w3-border">{loadError}</div>
-  {:else if assets.length}
-    <div class="summary-bar">
-      <span>{filtered.length} shown</span>
-      <span>{selectedIds.size} selected</span>
+  {:else if assets.length || notFoundTags.length}
+    {#if notFoundTags.length}
+      <div class="w3-panel w3-pale-yellow w3-border">
+        {notFoundTags.length} tag{notFoundTags.length === 1 ? "" : "s"} not found:
+        {notFoundTags.join(", ")}
+      </div>
+    {/if}
+
+    <div class="results-toolbar">
+      <span class="summary">{assets.length} loaded · {filtered.length} shown · {selectedIds.size} selected</span>
+
+      {#if uniqueModels.length > 1}
+        <label>
+          Filter model
+          <select class="w3-select w3-border" bind:value={filterModel}>
+            <option value="">All models</option>
+            {#each uniqueModels as m}
+              <option value={m}>{m}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+
       {#if selectedIds.size}
         <button
           class="w3-button w3-tiny w3-border"
@@ -250,23 +340,53 @@
   .purpose-manager {
     padding: 16px;
   }
-  .toolbar {
+  .load-panel {
+    margin-bottom: 16px;
+  }
+  .mode-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 12px;
+  }
+  .mode-option {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: bold;
+    cursor: pointer;
+    min-width: unset;
+  }
+  .mode-controls {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
     align-items: flex-end;
-    margin-bottom: 12px;
   }
-  .toolbar label {
+  .mode-controls label {
+    font-weight: bold;
+    min-width: 160px;
+  }
+  .tag-label {
+    min-width: min(400px, 100%) !important;
+  }
+  .tag-input {
+    font-family: monospace;
+    font-size: 13px;
+  }
+  .results-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+  .results-toolbar label {
     font-weight: bold;
     min-width: 140px;
   }
-  .summary-bar {
-    display: flex;
-    gap: 16px;
-    align-items: center;
+  .summary {
     font-size: 13px;
-    margin-bottom: 8px;
     color: #555;
   }
   .apply-bar {

--- a/src/ui/contracts/Invoices.svelte
+++ b/src/ui/contracts/Invoices.svelte
@@ -214,8 +214,7 @@
     <label>
       Search:
       <input
-        class="w3-input w3-border w3-small"
-        style="max-width: 220px; display:inline-block"
+        class="w3-input w3-border w3-small search-input"
         bind:value={search}
         placeholder="Email, asset tag, or ticket #"
       />
@@ -345,6 +344,10 @@
   }
   .filter-bar label {
     white-space: nowrap;
+  }
+  .search-input {
+    width: 240px;
+    display: inline-block;
   }
   .cost-input {
     width: 5.5em;

--- a/src/ui/contracts/Invoices.svelte
+++ b/src/ui/contracts/Invoices.svelte
@@ -70,6 +70,7 @@
           <th>Student Email</th>
           <th>Asset Tag</th>
           <th>Date Created</th>
+          <th>Type</th>
           <th>Ticket Info</th>
           <th>Repair Cost</th>
           <th>Contacts</th>
@@ -90,8 +91,17 @@
             <td class="date-created" title={r.fields["Date Created"]}
               >{formatDate(r.fields["Date Created"])}</td
             >
+            <td>
+              {#if r.fields["Cancellation"]}
+                <span class="w3-tag w3-red w3-small">Cancellation</span>
+              {:else}
+                Invoice
+              {/if}
+            </td>
             <td style="white-space: pre-wrap;"
-              >{fmtMultiline(r.fields["Ticket Block"])}</td
+              >{fmtMultiline(r.fields["Ticket Block"])}{#if r.fields["Note"]}
+                <div class="w3-text-red w3-small">{r.fields["Note"]}</div>
+              {/if}</td
             >
             <td>{formatCurrency(r.fields["Repair Cost (from Ticket)"])}</td>
             <td style="white-space: pre-wrap;"

--- a/src/ui/contracts/Invoices.svelte
+++ b/src/ui/contracts/Invoices.svelte
@@ -5,19 +5,181 @@
   import Loader from "@components/Loader.svelte";
 
   let loading = true;
-  let rows: InvoiceResult[] = [];
-  let ticketFilter = "";
+  let allRows: InvoiceResult[] = [];
 
   async function refresh() {
     loading = true;
-    rows = await getInvoices(
-      ticketFilter ? { ticketNumber: ticketFilter } : {}
-    );
+    allRows = await getInvoices({});
     loading = false;
   }
 
   onMount(refresh);
 
+  // ---- Filters ----
+  let search = "";
+  let datePreset: "schoolYear" | "month" | "week" | "all" = "schoolYear";
+  let typeFilter: "all" | "invoice" | "cancellation" = "all";
+  let minCost = "";
+  let maxCost = "";
+
+  // School year runs July 1 - June 30
+  function schoolYearStart(now: Date): Date {
+    const y = now.getMonth() >= 6 ? now.getFullYear() : now.getFullYear() - 1;
+    return new Date(y, 6, 1);
+  }
+
+  function presetStart(preset: typeof datePreset): Date | null {
+    const now = new Date();
+    switch (preset) {
+      case "week": {
+        const d = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        d.setDate(d.getDate() - d.getDay()); // back to Sunday
+        return d;
+      }
+      case "month":
+        return new Date(now.getFullYear(), now.getMonth(), 1);
+      case "schoolYear":
+        return schoolYearStart(now);
+      default:
+        return null;
+    }
+  }
+
+  // ---- Field accessors (lookup fields come back as arrays) ----
+  function joined(val: unknown): string {
+    if (Array.isArray(val)) return val.filter(Boolean).join(", ");
+    return (val as string) || "";
+  }
+
+  function costOf(r: InvoiceResult): number {
+    const v = r.fields["Repair Cost (from Ticket)"];
+    const n = Number(Array.isArray(v) ? v[0] : v);
+    return isNaN(n) ? 0 : n;
+  }
+
+  function ticketNumberOf(r: InvoiceResult): string {
+    return joined(r.fields["Number (from Ticket)"]);
+  }
+
+  function isCancellation(r: InvoiceResult): boolean {
+    return Boolean(r.fields["Cancellation"]);
+  }
+
+  function matchesSearch(r: InvoiceResult, needle: string): boolean {
+    if (!needle) return true;
+    const haystack = [
+      joined(r.fields["Student Email (from Student)"]),
+      joined(r.fields["Device Asset Tag (from Ticket)"]),
+      ticketNumberOf(r),
+      r.fields["Note"] || "",
+    ]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(needle.toLowerCase());
+  }
+
+  function filterRows(
+    rows: InvoiceResult[],
+    search: string,
+    datePreset,
+    typeFilter,
+    minCost: string,
+    maxCost: string
+  ): InvoiceResult[] {
+    const start = presetStart(datePreset);
+    const min = minCost === "" ? null : Number(minCost);
+    const max = maxCost === "" ? null : Number(maxCost);
+    return rows.filter((r) => {
+      if (start) {
+        const created = new Date(r.fields["Date Created"] || "");
+        if (isNaN(created.getTime()) || created < start) return false;
+      }
+      if (typeFilter === "invoice" && isCancellation(r)) return false;
+      if (typeFilter === "cancellation" && !isCancellation(r)) return false;
+      const cost = costOf(r);
+      if (min != null && !isNaN(min) && cost < min) return false;
+      if (max != null && !isNaN(max) && cost > max) return false;
+      return matchesSearch(r, search);
+    });
+  }
+
+  // ---- Sorting ----
+  let sortKey = "date";
+  let sortDir: "asc" | "desc" = "desc"; // newest first by default
+
+  const headers: { key: string; label: string }[] = [
+    { key: "email", label: "Student Email" },
+    { key: "asset", label: "Asset Tag" },
+    { key: "date", label: "Date Created" },
+    { key: "type", label: "Type" },
+    { key: "ticket", label: "Ticket Info" },
+    { key: "cost", label: "Repair Cost" },
+    { key: "contacts", label: "Contacts" },
+    { key: "delivered", label: "Delivered" },
+  ];
+
+  function sortValue(r: InvoiceResult, key: string): string | number {
+    switch (key) {
+      case "email":
+        return joined(r.fields["Student Email (from Student)"]).toLowerCase();
+      case "asset":
+        return joined(r.fields["Device Asset Tag (from Ticket)"]).toLowerCase();
+      case "date":
+        return new Date(r.fields["Date Created"] || 0).getTime() || 0;
+      case "type":
+        return isCancellation(r) ? 1 : 0;
+      case "ticket":
+        return Number(ticketNumberOf(r)) || 0;
+      case "cost":
+        return costOf(r);
+      case "contacts":
+        return joined(r.fields["Contact Info"]).toLowerCase();
+      case "delivered":
+        return r.fields["Email Sent"] ? 1 : 0;
+      default:
+        return "";
+    }
+  }
+
+  function setSort(key: string) {
+    if (sortKey === key) {
+      sortDir = sortDir === "asc" ? "desc" : "asc";
+    } else {
+      sortKey = key;
+      // Dates & costs read most naturally biggest/newest first
+      sortDir = key === "date" || key === "cost" ? "desc" : "asc";
+    }
+  }
+
+  function sortRows(rows: InvoiceResult[], key: string, dir: "asc" | "desc") {
+    const sorted = [...rows].sort((a, b) => {
+      const av = sortValue(a, key);
+      const bv = sortValue(b, key);
+      if (av < bv) return dir === "asc" ? -1 : 1;
+      if (av > bv) return dir === "asc" ? 1 : -1;
+      return 0;
+    });
+    return sorted;
+  }
+
+  $: filteredRows = filterRows(
+    allRows,
+    search,
+    datePreset,
+    typeFilter,
+    minCost,
+    maxCost
+  );
+  $: displayRows = sortRows(filteredRows, sortKey, sortDir);
+
+  // Net = invoices minus cancellations
+  $: netTotal = filteredRows.reduce(
+    (sum, r) => sum + (isCancellation(r) ? -costOf(r) : costOf(r)),
+    0
+  );
+  $: cancellationCount = filteredRows.filter(isCancellation).length;
+
+  // ---- Formatting ----
   function fmtMultiline(val: unknown): string {
     if (Array.isArray(val)) return val.filter(Boolean).join("\n");
     if (typeof val === "string") return val;
@@ -48,37 +210,93 @@
 <div class="w3-container">
   <h3>Invoices</h3>
 
-  <div class="w3-margin-bottom">
-    <label for="ticketFilter">Filter by Ticket:</label>
-    &nbsp;
-    <input
-      id="ticketFilter"
-      class="w3-input w3-border w3-small"
-      style="max-width: 260px; display:inline-block"
-      bind:value={ticketFilter}
-      placeholder="Ticket ID"
-    />
-    <button class="w3-button w3-blue w3-small" on:click={refresh}>Apply</button>
+  <div class="filter-bar w3-margin-bottom">
+    <label>
+      Search:
+      <input
+        class="w3-input w3-border w3-small"
+        style="max-width: 220px; display:inline-block"
+        bind:value={search}
+        placeholder="Email, asset tag, or ticket #"
+      />
+    </label>
+    <label>
+      Dates:
+      <select
+        class="w3-select w3-border w3-small"
+        style="width:auto; display:inline-block"
+        bind:value={datePreset}
+      >
+        <option value="schoolYear">This school year</option>
+        <option value="month">This month</option>
+        <option value="week">This week</option>
+        <option value="all">All time</option>
+      </select>
+    </label>
+    <label>
+      Type:
+      <select
+        class="w3-select w3-border w3-small"
+        style="width:auto; display:inline-block"
+        bind:value={typeFilter}
+      >
+        <option value="all">All</option>
+        <option value="invoice">Invoices</option>
+        <option value="cancellation">Cancellations</option>
+      </select>
+    </label>
+    <label>
+      Cost:
+      <input
+        class="w3-input w3-border w3-small cost-input"
+        type="number"
+        min="0"
+        bind:value={minCost}
+        placeholder="min"
+      />
+      –
+      <input
+        class="w3-input w3-border w3-small cost-input"
+        type="number"
+        min="0"
+        bind:value={maxCost}
+        placeholder="max"
+      />
+    </label>
+    <button class="w3-button w3-blue w3-small" on:click={refresh}
+      >Refresh</button
+    >
   </div>
 
   {#if loading}
     <Loader text="Loading invoices" working={true} />
   {:else}
+    <p class="w3-small">
+      Showing <b>{displayRows.length}</b> of {allRows.length} records
+      {#if cancellationCount}
+        ({cancellationCount} cancellation{cancellationCount === 1 ? "" : "s"})
+      {/if}
+      — net billed: <b>{formatCurrency(netTotal)}</b>
+    </p>
     <table class="w3-table w3-striped w3-bordered w3-small">
       <thead>
         <tr>
-          <th>Student Email</th>
-          <th>Asset Tag</th>
-          <th>Date Created</th>
-          <th>Type</th>
-          <th>Ticket Info</th>
-          <th>Repair Cost</th>
-          <th>Contacts</th>
-          <th>Delivered</th>
+          {#each headers as h (h.key)}
+            <th
+              class="sortable"
+              on:click={() => setSort(h.key)}
+              title="Sort by {h.label}"
+            >
+              {h.label}
+              {#if sortKey === h.key}
+                <span class="sort-arrow">{sortDir === "asc" ? "▲" : "▼"}</span>
+              {/if}
+            </th>
+          {/each}
         </tr>
       </thead>
       <tbody>
-        {#each rows as r}
+        {#each displayRows as r (r.id)}
           <tr>
             <td
               >{(r.fields["Student Email (from Student)"] || []).join(", ")}</td
@@ -103,7 +321,7 @@
                 <div class="w3-text-red w3-small">{r.fields["Note"]}</div>
               {/if}</td
             >
-            <td>{formatCurrency(r.fields["Repair Cost (from Ticket)"])}</td>
+            <td>{formatCurrency(costOf(r))}</td>
             <td style="white-space: pre-wrap;"
               >{fmtMultiline(r.fields["Contact Info"])}</td
             >
@@ -118,5 +336,29 @@
 <style>
   .date-created {
     white-space: nowrap;
+  }
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+  }
+  .filter-bar label {
+    white-space: nowrap;
+  }
+  .cost-input {
+    width: 5.5em;
+    display: inline-block;
+  }
+  th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+  }
+  th.sortable:hover {
+    background: #f0f0f0;
+  }
+  .sort-arrow {
+    font-size: 0.8em;
   }
 </style>

--- a/src/ui/people/students/LookupStudent.svelte
+++ b/src/ui/people/students/LookupStudent.svelte
@@ -8,6 +8,7 @@
   import AssetDisplay from "@assets/AssetDisplay.svelte";
   import SignoutHistoryTable from "@history/SignoutHistoryTable.svelte";
   import { validateStudent, studentName } from "@utils/validators";
+  import { l } from "@utils/util";
   import FormField from "@components/FormField.svelte";
   import SimpleForm from "@components/SimpleForm.svelte";
   import NameDropdown from "@people/components/NameDropdown.svelte";
@@ -163,8 +164,18 @@
               {loansLoaded ? "No current loans" : "Fetching..."}
             </p>
           {:else}
-            {#each current as asset}
-              <AssetDisplay {asset} />
+            {#each current as asset (asset["Asset Tag"])}
+              <div class="current-loan">
+                <AssetDisplay {asset} />
+                <a
+                  class="w3-small"
+                  href={`/checkout/lost/${asset["Asset Tag"]}`}
+                  on:click={l(`/checkout/lost/${asset["Asset Tag"]}`)}
+                  title="Open the check-in screen with this device pre-filled and 'Mark as Lost' selected"
+                >
+                  Device missing? Mark as lost &amp; bill family…
+                </a>
+              </div>
             {:else}
               No current loans
             {/each}
@@ -209,5 +220,11 @@
   }
   input {
     width: min(100vh - 32px, 800px);
+  }
+  .current-loan {
+    margin-bottom: 8px;
+  }
+  .current-loan a {
+    margin-left: 8px;
   }
 </style>

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -5,6 +5,13 @@
   import DataExporter from "./DataExporter.svelte";
   import BulkMessageSender from "@notifications/BulkMessageSender.svelte";
   import { signoutAsset } from "@data/signout";
+  import { updateAsset } from "@data/inventory";
+  import {
+    billForLostDevice,
+    getBillableStudentId,
+    DEFAULT_REPLACEMENT_COST,
+  } from "@data/lostDeviceBilling";
+  import { showToast } from "@components/toastStore";
 
   export let data;
   export let columns = [];
@@ -321,9 +328,18 @@
 
   let showLostConfirm = false;
   let lostNote = "";
+  let billForReplacement = false;
+  let replacementCost = DEFAULT_REPLACEMENT_COST;
+
+  $: billableSelectedCount = [...selectedAssetTags].filter((tag) => {
+    const asset = data.find((row) => row["Asset Tag"] === tag);
+    return asset && getBillableStudentId(asset);
+  }).length;
 
   function openLostConfirm() {
     lostNote = "";
+    billForReplacement = false;
+    replacementCost = DEFAULT_REPLACEMENT_COST;
     showLostConfirm = true;
   }
   function closeLostConfirm() {
@@ -335,15 +351,52 @@
     updateStatusError = "";
     try {
       const tags = [...selectedAssetTags];
+      const billingErrors = [];
+      let billedCount = 0;
       await Promise.all(
         tags.map(async (tag) => {
           const asset = data.find((row) => row["Asset Tag"] === tag);
           if (!asset) throw new Error(`Asset not found: ${tag}`);
-          await signoutAsset(null, null, asset, lostNote, "Lost", false);
+          // Bill first so the signout note can record the ticket number.
+          let note = lostNote;
+          if (billForReplacement) {
+            if (!getBillableStudentId(asset)) {
+              billingErrors.push(`${tag}: no current student to bill`);
+            } else {
+              try {
+                const { ticket } = await billForLostDevice(asset, {
+                  cost: replacementCost,
+                  note: lostNote,
+                });
+                note =
+                  (lostNote ? lostNote + " " : "") +
+                  `Billed family $${replacementCost} for replacement` +
+                  (ticket.Number ? ` (Ticket #${ticket.Number}).` : ".");
+                billedCount++;
+              } catch (e) {
+                billingErrors.push(`${tag}: ${e.message}`);
+              }
+            }
+          }
+          await signoutAsset(null, null, asset, note, "Lost", false);
+          await updateAsset(asset._id, { Status: "Lost" });
         }),
       );
-      selectedAssetTags = new Set();
-      closeLostConfirm();
+      if (billingErrors.length) {
+        updateStatusError = `Marked as lost, but some invoices could not be sent — ${billingErrors.join("; ")}`;
+        if (billedCount) {
+          showToast(`Queued ${billedCount} invoice(s)`, "info");
+        }
+      } else {
+        showToast(
+          billForReplacement
+            ? `Marked ${tags.length} device(s) lost and queued ${billedCount} invoice(s) for the business office`
+            : `Marked ${tags.length} device(s) lost`,
+          "success",
+        );
+        selectedAssetTags = new Set();
+        closeLostConfirm();
+      }
     } catch (e) {
       updateStatusError = e.message || "Failed to update status.";
     } finally {
@@ -743,13 +796,51 @@
           bind:value={lostNote}
           placeholder="Add a note (optional)"
         ></textarea>
+        <div class="w3-margin-top">
+          <label>
+            <input
+              type="checkbox"
+              class="w3-check"
+              bind:checked={billForReplacement}
+              disabled={isUpdatingStatus}
+            />
+            Bill family for replacement
+          </label>
+          {#if billForReplacement}
+            <div class="w3-margin-top">
+              <label for="replacement-cost">Replacement cost ($):</label>
+              <input
+                id="replacement-cost"
+                type="number"
+                min="0"
+                class="w3-input w3-border"
+                bind:value={replacementCost}
+                disabled={isUpdatingStatus}
+              />
+            </div>
+            <p class="w3-small w3-text-gray">
+              {billableSelectedCount} of {selectedAssetTags.size} selected device(s)
+              have a current student and can be billed. For each, we'll create a
+              closed "Lost" ticket with the replacement cost and ask the business
+              office to send an invoice to the family.
+            </p>
+          {/if}
+        </div>
         <div class="w3-bar w3-margin-top">
           <button
             class="w3-button w3-orange w3-bar-item"
             on:click={confirmMarkSelectedAsLost}
-            disabled={isUpdatingStatus}
+            disabled={isUpdatingStatus ||
+              (billForReplacement &&
+                (!replacementCost || replacementCost <= 0))}
           >
-            {isUpdatingStatus ? "Marking as Lost..." : "Confirm"}
+            {isUpdatingStatus
+              ? billForReplacement
+                ? "Marking lost & sending invoices..."
+                : "Marking as Lost..."
+              : billForReplacement
+                ? "Confirm & Send Invoice(s)"
+                : "Confirm"}
           </button>
         </div>
         {#if updateStatusError}
@@ -820,6 +911,12 @@
     overflow: auto;
     display: flex;
     flex-direction: column;
+  }
+  .modal-content.lost-confirm-modal {
+    width: auto;
+    height: auto;
+    max-height: 90vh;
+    border-radius: 8px;
   }
   .modal-bulk-message .modal-content {
     width: 100vw;

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -1045,6 +1045,11 @@
     color: #bf360c;
     border: 1px solid #ffcc80;
   }
+  .purpose-pill.purpose-temp {
+    background: #f5f5f5;
+    color: #616161;
+    border: 1px solid #bdbdbd;
+  }
   .error-details {
     margin-top: 8px;
   }

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -339,6 +339,7 @@
         "Machine Number": machine ? machineIndex + 1 : "",
         "Machine Count": row.lastUsedMachineCount,
         "Asset Tag": machine?.assetTag || "",
+        Purpose: machine?.purpose || "",
         Serial: machine?.serial || "",
         "Last Activity Date": machine?.lastUsed || "",
         "Google Last Sync": machine?.googleData?.lastSync || "",
@@ -626,6 +627,7 @@
             "Machine Number",
             "Machine Count",
             "Asset Tag",
+            "Purpose",
             "Serial",
             "Last Activity Date",
             "Google Last Sync",
@@ -736,6 +738,7 @@
               <th on:click={() => setSort("student")}>Student</th>
               <th on:click={() => setSort("status")}>Status</th>
               <th>Machine</th>
+              <th>Purpose</th>
               <th>Last Activity</th>
               <th>Checkout Status</th>
               <th on:click={() => setSort("summary")}>Summary</th>
@@ -792,6 +795,13 @@
                     >
                   {/if}
                 </td>
+                <td class="purpose-cell">
+                  {#if displayRow.machine?.purpose}
+                    <span class="purpose-pill purpose-{displayRow.machine.purpose.toLowerCase().replace(/\s+/g, '-')}"
+                      >{displayRow.machine.purpose}</span
+                    >
+                  {/if}
+                </td>
                 <td>
                   {#if displayRow.machine}
                     <div>
@@ -832,7 +842,7 @@
               </tr>
               {#if expandedMachines[displayRow.key] && displayRow.machine}
                 <tr class="expanded-row">
-                  <td colspan="7">
+                  <td colspan="8">
                     <div class="expanded-grid">
                       <div>
                         <h4>Recent Users</h4>
@@ -1007,6 +1017,33 @@
   .status-unknown {
     background: #eeeeee;
     color: #424242;
+  }
+  .purpose-cell {
+    white-space: nowrap;
+  }
+  .purpose-pill {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: #eeeeee;
+    color: #424242;
+  }
+  .purpose-pill.purpose-mcas {
+    background: #111;
+    color: #ff4444;
+    border: 1px solid #ff4444;
+  }
+  .purpose-pill.purpose-daily-loaner {
+    background: #e3f2fd;
+    color: #0d47a1;
+    border: 1px solid #90caf9;
+  }
+  .purpose-pill.purpose-staff-spare {
+    background: #fff3e0;
+    color: #bf360c;
+    border: 1px solid #ffcc80;
   }
   .error-details {
     margin-top: 8px;

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -10,6 +10,7 @@
     type StudentDeviceReportMachine,
     type StudentDeviceReportRow,
   } from "@data/studentDeviceReport";
+  import { INACTIVE_PURPOSES } from "@data/inventory";
 
   type SortColumn =
     | "student"
@@ -63,6 +64,7 @@
   let sortColumn: SortColumn = "lastUsedMachineCount";
   let sortDirection: "asc" | "desc" = "desc";
   let selectedStatuses: Set<string> = new Set();
+  let hideRetired = true;
   let expandedMachines = {};
   let tableScrollEl: HTMLDivElement | null = null;
   let topScrollEl: HTMLDivElement | null = null;
@@ -87,6 +89,7 @@
   $: displayRows = filterAndSortDisplayRows(
     allDisplayRows,
     selectedStatuses,
+    hideRetired,
     sortColumn,
     sortDirection,
   );
@@ -370,12 +373,15 @@
   function filterAndSortDisplayRows(
     reportRows: DisplayRow[],
     selected: Set<string>,
+    hideInactive: boolean,
     column: SortColumn,
     direction: "asc" | "desc",
   ) {
-    const filtered = reportRows.filter((displayRow) =>
-      matchesStatusFilter(displayRow, selected),
-    );
+    const filtered = reportRows.filter((displayRow) => {
+      if (!matchesStatusFilter(displayRow, selected)) return false;
+      if (hideInactive && displayRow.machine?.purpose && INACTIVE_PURPOSES.includes(displayRow.machine.purpose)) return false;
+      return true;
+    });
 
     if (column !== "summary") {
       return filtered;
@@ -641,6 +647,13 @@
         />
       {/if}
     </div>
+
+    {#if rows.length}
+      <label class="retired-toggle">
+        <input type="checkbox" bind:checked={hideRetired} />
+        Hide Disposed/Retired machines
+      </label>
+    {/if}
 
     {#if rows.length && availableStatuses.length}
       <div class="status-filter-section">
@@ -1057,6 +1070,14 @@
     white-space: pre-wrap;
     margin: 6px 0 0;
     font-size: 12px;
+  }
+  .retired-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: normal;
+    cursor: pointer;
+    min-width: unset;
   }
   .status-filter-section {
     width: 100%;

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -11,6 +11,7 @@
     type StudentDeviceReportRow,
   } from "@data/studentDeviceReport";
   import { INACTIVE_PURPOSES } from "@data/inventory";
+  import PurposeBadge from "@assets/PurposeBadge.svelte";
 
   type SortColumn =
     | "student"
@@ -809,11 +810,7 @@
                   {/if}
                 </td>
                 <td class="purpose-cell">
-                  {#if displayRow.machine?.purpose}
-                    <span class="purpose-pill purpose-{displayRow.machine.purpose.toLowerCase().replace(/\s+/g, '-')}"
-                      >{displayRow.machine.purpose}</span
-                    >
-                  {/if}
+                  <PurposeBadge purpose={displayRow.machine?.purpose} showFallback={true} />
                 </td>
                 <td>
                   {#if displayRow.machine}
@@ -1033,35 +1030,6 @@
   }
   .purpose-cell {
     white-space: nowrap;
-  }
-  .purpose-pill {
-    display: inline-block;
-    font-size: 11px;
-    font-weight: bold;
-    padding: 2px 6px;
-    border-radius: 4px;
-    background: #eeeeee;
-    color: #424242;
-  }
-  .purpose-pill.purpose-mcas {
-    background: #111;
-    color: #ff4444;
-    border: 1px solid #ff4444;
-  }
-  .purpose-pill.purpose-daily-loaner {
-    background: #e3f2fd;
-    color: #0d47a1;
-    border: 1px solid #90caf9;
-  }
-  .purpose-pill.purpose-staff-spare {
-    background: #fff3e0;
-    color: #bf360c;
-    border: 1px solid #ffcc80;
-  }
-  .purpose-pill.purpose-temp {
-    background: #f5f5f5;
-    color: #616161;
-    border: 1px solid #bdbdbd;
   }
   .error-details {
     margin-top: 8px;


### PR DESCRIPTION
## Summary

- **`MachinePurpose` type** in `inventory.ts` — union of known purposes plus `(string & {})` so Airtable values are still accepted but IDEs suggest the known values. Also exports `ALL_PURPOSES` array for dropdowns.
- **AssetDisplay badges** — three inline badges appear next to the model name:
  - `MCAS` → red text on black (`MCAS`) — clear warning that this device shouldn't be loaned out
  - `Daily Loaner` → blue `DL` badge
  - `Staff Spare` → amber `Spare` badge (signals "classroom pool device")
- **Student device report** — `purpose` is now a top-level field on `StudentDeviceReportMachine` and surfaces as a styled **Purpose** column in both the table and CSV export.
- **Purpose Manager** (`/it/purposes/`, IT-only) — load all Chromebooks, filter by current purpose and/or model, multi-select rows (with select-all for filtered view), then bulk-update to any purpose in one click. Intended for end-of-year rotations like MCAS → Student Loan.

## Test plan

- [ ] AssetDisplay: find a machine with Purpose = MCAS/Daily Loaner/Staff Spare and confirm the badge appears in signout, lookup, and the student device report Machine column
- [ ] Student device report: run a report and confirm Purpose column appears in the table and in the downloaded CSV
- [ ] Purpose Manager: navigate to `/it/purposes/` (IT user required), load chromebooks, filter by MCAS, select all, change to Student Loan, click Apply — confirm Airtable updates
- [ ] Non-IT users should not see Purpose Manager in the nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)