### PR TITLE
Add temp-device swap workflow to check-in/out

### DIFF
--- a/src/data/tempDevice.ts
+++ b/src/data/tempDevice.ts
@@ -1,4 +1,3 @@
-import { logger } from "@utils/log";
 import { get } from "svelte/store";
 import { user } from "./user";
 import {
@@ -26,34 +25,30 @@ function tempTagOf(ticket: Ticket): string | undefined {
 /**
  * Open tickets that currently list `assetTag` as their Temporary Device.
  * Used on check-in to offer to unlink a temp loaner being returned.
+ *
+ * Throws on fetch failure so callers can distinguish "lookup failed, retry"
+ * from "no matching tickets" rather than treating both as an empty result.
  */
 export async function getOpenTicketsWithTempDevice(
   assetTag: string
 ): Promise<Ticket[]> {
-  try {
-    const tickets = await getTicketsForAsset(assetTag);
-    return tickets.filter((t) => isOpen(t) && tempTagOf(t) === assetTag);
-  } catch (e) {
-    logger.logError("Failed to look up tickets with temp device:", e);
-    return [];
-  }
+  const tickets = await getTicketsForAsset(assetTag);
+  return tickets.filter((t) => isOpen(t) && tempTagOf(t) === assetTag);
 }
 
 /**
  * Open tickets belonging to a student — used on check-out to offer to link a
  * freshly loaned device as that ticket's temporary device.
+ *
+ * Throws on fetch failure (see note above); returns [] only when the student
+ * genuinely has no email or no open tickets.
  */
 export async function getOpenTicketsForStudentObj(
   student: Student
 ): Promise<Ticket[]> {
   if (!student?.Email) return [];
-  try {
-    const tickets = await getTicketsForStudent(student.Email);
-    return tickets.filter(isOpen);
-  } catch (e) {
-    logger.logError("Failed to look up open tickets for student:", e);
-    return [];
-  }
+  const tickets = await getTicketsForStudent(student.Email);
+  return tickets.filter(isOpen);
 }
 
 function appendHistory(

--- a/src/data/tempDevice.ts
+++ b/src/data/tempDevice.ts
@@ -1,0 +1,127 @@
+import { logger } from "@utils/log";
+import { get } from "svelte/store";
+import { user } from "./user";
+import {
+  getTicketsForAsset,
+  getTicketsForStudent,
+  updateTicket,
+} from "./tickets";
+import type { Ticket } from "./tickets";
+import type { Asset } from "./inventory";
+import type { Student } from "./students";
+
+// A ticket counts as "open" for temp-swap purposes if it isn't Closed.
+function isOpen(ticket: Ticket): boolean {
+  return ticket["Ticket Status"] !== "Closed";
+}
+
+// Asset Tag that a ticket currently lists as its Temporary Device, if any.
+function tempTagOf(ticket: Ticket): string | undefined {
+  return (
+    (ticket as any)._linked?.["Temporary Device"]?.["Asset Tag"] ||
+    (ticket as any)["Asset Tag (from Temporary Device)"]?.[0]
+  );
+}
+
+/**
+ * Open tickets that currently list `assetTag` as their Temporary Device.
+ * Used on check-in to offer to unlink a temp loaner being returned.
+ */
+export async function getOpenTicketsWithTempDevice(
+  assetTag: string
+): Promise<Ticket[]> {
+  try {
+    const tickets = await getTicketsForAsset(assetTag);
+    return tickets.filter((t) => isOpen(t) && tempTagOf(t) === assetTag);
+  } catch (e) {
+    logger.logError("Failed to look up tickets with temp device:", e);
+    return [];
+  }
+}
+
+/**
+ * Open tickets belonging to a student — used on check-out to offer to link a
+ * freshly loaned device as that ticket's temporary device.
+ */
+export async function getOpenTicketsForStudentObj(
+  student: Student
+): Promise<Ticket[]> {
+  if (!student?.Email) return [];
+  try {
+    const tickets = await getTicketsForStudent(student.Email);
+    return tickets.filter(isOpen);
+  } catch (e) {
+    logger.logError("Failed to look up open tickets for student:", e);
+    return [];
+  }
+}
+
+function appendHistory(
+  ticket: Ticket,
+  entry: Record<string, unknown>
+): string {
+  let entries: any[] = [];
+  try {
+    entries = JSON.parse(ticket.History || "{}").entries || [];
+  } catch (e) {
+    // unparseable history — start fresh rather than fail the swap
+  }
+  entries.push({
+    timestamp: new Date().toISOString(),
+    user: (get(user) as any)?.email || "system",
+    ...entry,
+  });
+  return JSON.stringify({ entries });
+}
+
+/**
+ * Remove a device as the temporary device on a ticket (e.g. a flaky loaner is
+ * being returned). Sets Temp Status back to "Needed" since the student still
+ * has a device in repair and may need another loaner.
+ */
+export async function unlinkTempDevice(
+  ticket: Ticket,
+  assetTag: string
+): Promise<Ticket> {
+  const history = appendHistory(ticket, {
+    action: "temp_device_unlinked",
+    status: ticket["Ticket Status"],
+    note: `Removed temp device ${assetTag} (returned at check-in).`,
+    changes: {
+      "Temporary Device": { from: (ticket as any)["Temporary Device"], to: [] },
+      "Temp Status": { from: ticket["Temp Status"], to: "Needed" },
+    },
+  });
+  return await updateTicket(ticket._id, {
+    "Temporary Device": [] as any,
+    "Temp Status": "Needed",
+    History: history,
+  } as Partial<Ticket>);
+}
+
+/**
+ * Link a device as the temporary device on a ticket (e.g. handing a student a
+ * loaner while their machine is in repair). Sets Temp Status to "Loaned".
+ */
+export async function linkTempDevice(
+  ticket: Ticket,
+  asset: Asset
+): Promise<Ticket> {
+  const history = appendHistory(ticket, {
+    action: "temp_device_linked",
+    status: ticket["Ticket Status"],
+    note: `Linked temp device ${asset["Asset Tag"]} (loaned at check-out).`,
+    changes: {
+      "Temporary Device": {
+        from: (ticket as any)["Temporary Device"],
+        to: [asset._id],
+      },
+      "Temp Status": { from: ticket["Temp Status"], to: "Loaned" },
+    },
+  });
+  return await updateTicket(ticket._id, {
+    "Temporary Device": [asset._id] as any,
+    "Temp Status": "Loaned",
+    History: history,
+  } as Partial<Ticket>);
+}

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -138,7 +138,14 @@
     });
 
     router("/tickets/", (ctx) => {
+      params = {};
       page = TicketBrowser;
+      title = "Ticket Browser";
+    });
+    router("/tickets/new/device/:tag", (ctx) => {
+      params = { newDeviceTag: ctx.params.tag };
+      page = TicketBrowser;
+      update += 1; // remount so the draft is created from the new tag
       title = "Ticket Browser";
     });
     router("/invoices/", (ctx) => {

--- a/src/ui/assets/Checkout.svelte
+++ b/src/ui/assets/Checkout.svelte
@@ -300,11 +300,18 @@
     selectedTempTicketId = "";
     linkTempForCheckout = false;
     linkTempTouched = false;
-    const tickets = await getOpenTicketsForStudentObj(student);
-    // Guard against a later student selection winning the race
-    if (student._id !== lastTicketStudentId) return;
-    studentOpenTickets = tickets;
-    if (tickets.length) selectedTempTicketId = tickets[0]._id;
+    try {
+      const tickets = await getOpenTicketsForStudentObj(student);
+      // Guard against a later student selection winning the race
+      if (student._id !== lastTicketStudentId) return;
+      studentOpenTickets = tickets;
+      if (tickets.length) selectedTempTicketId = tickets[0]._id;
+    } catch (e) {
+      logger.logError("Failed to load student open tickets:", e);
+      // Clear the guard so a later interaction retries instead of being
+      // stuck with no checkbox until the page is refreshed.
+      if (student._id === lastTicketStudentId) lastTicketStudentId = null;
+    }
   }
 
   // Default the link on for a Temp-purpose loaner, but only until the user

--- a/src/ui/assets/Checkout.svelte
+++ b/src/ui/assets/Checkout.svelte
@@ -49,6 +49,13 @@
     DEFAULT_REPLACEMENT_COST,
   } from "@data/lostDeviceBilling";
   import { showToast } from "@components/toastStore";
+  import {
+    getOpenTicketsWithTempDevice,
+    getOpenTicketsForStudentObj,
+    unlinkTempDevice,
+    linkTempDevice,
+  } from "@data/tempDevice";
+  import type { Ticket } from "@data/tickets";
 
   // Set via the /checkout/lost/:tag route to land here with the asset
   // pre-filled and "Mark as Lost" selected (e.g. from student lookup).
@@ -232,6 +239,93 @@
     (asset) => asset && getBillableStudentId(asset)
   );
 
+  // --- Temp device swap: checking IN a device that's a temp on a ticket ---
+  // tag -> open Ticket that lists it as Temporary Device (or null if none)
+  let tempTicketsByTag: Record<string, Ticket | null> = {};
+  let tempTicketLookups = new Set<string>();
+  // tag -> whether to unlink (default true)
+  let unlinkTempByTag: Record<string, boolean> = {};
+
+  $: returnedTempAssets =
+    (status == "Returned" &&
+      (assets || []).filter(
+        (a) => a && tempTicketsByTag[a["Asset Tag"]]
+      )) ||
+    [];
+  $: if (status == "Returned") lookupTempTickets(assets);
+
+  async function lookupTempTickets(assets) {
+    for (let asset of assets || []) {
+      if (!asset) continue;
+      const tag = asset["Asset Tag"];
+      if (tempTicketLookups.has(tag)) continue;
+      tempTicketLookups.add(tag);
+      try {
+        const tickets = await getOpenTicketsWithTempDevice(tag);
+        tempTicketsByTag = { ...tempTicketsByTag, [tag]: tickets[0] || null };
+        if (tickets[0] && unlinkTempByTag[tag] === undefined) {
+          unlinkTempByTag = { ...unlinkTempByTag, [tag]: true };
+        }
+      } catch (e) {
+        logger.logError("Failed to look up temp-device tickets:", e);
+        tempTicketLookups.delete(tag); // allow retry
+      }
+    }
+  }
+
+  // --- Temp device swap: checking OUT a loaner to a student with a ticket ---
+  let studentOpenTickets: Ticket[] = [];
+  let lastTicketStudentId: string | null = null;
+  let linkTempForCheckout = false;
+  let linkTempTouched = false; // user overrode the default — stop auto-setting
+  let lastCheckoutTag = "";
+  let selectedTempTicketId = "";
+  // Only offer linking on a single-device checkout (a ticket has one temp).
+  $: checkoutAsset =
+    status == "Out" && studentMode && (assets || []).length === 1
+      ? assets[0]
+      : null;
+
+  $: if (status == "Out" && studentMode && student) {
+    loadStudentOpenTickets(student);
+  } else if (!student) {
+    studentOpenTickets = [];
+    lastTicketStudentId = null;
+  }
+
+  async function loadStudentOpenTickets(student) {
+    if (student._id === lastTicketStudentId) return;
+    lastTicketStudentId = student._id;
+    studentOpenTickets = [];
+    selectedTempTicketId = "";
+    linkTempForCheckout = false;
+    linkTempTouched = false;
+    const tickets = await getOpenTicketsForStudentObj(student);
+    // Guard against a later student selection winning the race
+    if (student._id !== lastTicketStudentId) return;
+    studentOpenTickets = tickets;
+    if (tickets.length) selectedTempTicketId = tickets[0]._id;
+  }
+
+  // Default the link on for a Temp-purpose loaner, but only until the user
+  // overrides it; re-derive when the checkout device changes.
+  $: if (checkoutAsset && checkoutAsset["Asset Tag"] !== lastCheckoutTag) {
+    lastCheckoutTag = checkoutAsset["Asset Tag"];
+    linkTempTouched = false;
+  }
+  $: if (checkoutAsset && studentOpenTickets.length && !linkTempTouched) {
+    linkTempForCheckout = checkoutAsset.Purpose === "Temp";
+  }
+
+  // Distinct asset tags just checked back in, for the "open a ticket" shortcut.
+  $: recentReturnedTags = [
+    ...new Set(
+      checkedOut
+        .filter((r) => r.status === "Returned" && r.asset)
+        .map((r) => r.asset["Asset Tag"])
+    ),
+  ];
+
   async function billLostAsset(asset) {
     $checkoutStatus = `Sending invoice for ${asset["Asset Tag"]}`;
     try {
@@ -322,6 +416,62 @@
             await updateAsset(asset._id, { Status: "Active" });
           }
         }
+        // Temp swap: returned a loaner that's a temp on a ticket -> unlink it
+        if (
+          success &&
+          asset &&
+          status == "Returned" &&
+          unlinkTempByTag[asset["Asset Tag"]] &&
+          tempTicketsByTag[asset["Asset Tag"]]
+        ) {
+          const t = tempTicketsByTag[asset["Asset Tag"]];
+          $checkoutStatus = `Updating Ticket #${t.Number}`;
+          try {
+            await unlinkTempDevice(t, asset["Asset Tag"]);
+            showToast(
+              `Removed ${asset["Asset Tag"]} as temp device on Ticket #${t.Number}`,
+              "success"
+            );
+          } catch (e) {
+            logger.logError("Failed to unlink temp device:", e);
+            showToast(
+              `Couldn't update Ticket #${t.Number}: ${e.message}`,
+              "error"
+            );
+          }
+          $checkoutStatus = "";
+        }
+        // Temp swap: loaned a device to a ticket-holder -> link it as temp
+        if (
+          success &&
+          asset &&
+          status == "Out" &&
+          linkTempForCheckout &&
+          selectedTempTicketId &&
+          checkoutAsset &&
+          asset["Asset Tag"] === checkoutAsset["Asset Tag"]
+        ) {
+          const t = studentOpenTickets.find(
+            (x) => x._id === selectedTempTicketId
+          );
+          if (t) {
+            $checkoutStatus = `Linking to Ticket #${t.Number}`;
+            try {
+              await linkTempDevice(t, asset);
+              showToast(
+                `Linked ${asset["Asset Tag"]} as temp device on Ticket #${t.Number}`,
+                "success"
+              );
+            } catch (e) {
+              logger.logError("Failed to link temp device:", e);
+              showToast(
+                `Couldn't update Ticket #${t.Number}: ${e.message}`,
+                "error"
+              );
+            }
+            $checkoutStatus = "";
+          }
+        }
       }
     }
     /* if (charger) {
@@ -338,6 +488,16 @@
       $assetTags = [];
       notes = "";
       billLostReplacement = false;
+      // Reset temp-swap state for the next transaction
+      tempTicketsByTag = {};
+      tempTicketLookups = new Set();
+      unlinkTempByTag = {};
+      studentOpenTickets = [];
+      lastTicketStudentId = null;
+      linkTempForCheckout = false;
+      linkTempTouched = false;
+      lastCheckoutTag = "";
+      selectedTempTicketId = "";
       $screenNote = null;
       $keyboardNote = null;
       $powerNote = null;
@@ -714,6 +874,62 @@ Hinge bolts:New screws needed for display hinges*/
         </FormField>
       </div>
     {/if}
+    {#if status == "Returned" && returnedTempAssets.length}
+      <div in:fly|local={{ y: -30 }} out:fade|local class="row">
+        <FormField name="Temp Device">
+          <div>
+            {#each returnedTempAssets as asset (asset["Asset Tag"])}
+              {@const t = tempTicketsByTag[asset["Asset Tag"]]}
+              {#if t}
+                <label class:bold={unlinkTempByTag[asset["Asset Tag"]]}>
+                  <input
+                    type="checkbox"
+                    bind:checked={unlinkTempByTag[asset["Asset Tag"]]}
+                  />
+                  Remove <b>{asset["Asset Tag"]}</b> as the temp device on
+                  Ticket #{t.Number}
+                </label>
+              {/if}
+            {/each}
+          </div>
+        </FormField>
+      </div>
+    {/if}
+    {#if checkoutAsset && studentOpenTickets.length}
+      <div in:fly|local={{ y: -30 }} out:fade|local class="row">
+        <FormField name="Temp Device">
+          <div>
+            <label class:bold={linkTempForCheckout}>
+              <input
+                type="checkbox"
+                bind:checked={linkTempForCheckout}
+                on:change={() => (linkTempTouched = true)}
+              />
+              Link <b>{checkoutAsset["Asset Tag"]}</b> as the temp device for
+              {#if studentOpenTickets.length === 1}
+                Ticket #{studentOpenTickets[0].Number}
+              {:else}
+                ticket:
+              {/if}
+            </label>
+            {#if studentOpenTickets.length > 1}
+              <select
+                class="w3-select w3-border"
+                style="width:auto; display:inline-block; margin-left:8px;"
+                bind:value={selectedTempTicketId}
+                disabled={!linkTempForCheckout}
+              >
+                {#each studentOpenTickets as t (t._id)}
+                  <option value={t._id}>
+                    #{t.Number} — {t["Ticket Status"]}
+                  </option>
+                {/each}
+              </select>
+            {/if}
+          </div>
+        </FormField>
+      </div>
+    {/if}
     {#if status == "Returned"}
       <div in:fly|local={{ y: -30 }} out:fade|local class="row">
         <FormField name="Machine Notes">
@@ -853,6 +1069,20 @@ Hinge bolts:New screws needed for display hinges*/
   </SimpleForm>
 </article>
 <article class="w3-container">
+  {#if recentReturnedTags.length}
+    <div class="w3-margin-bottom">
+      <span class="w3-small w3-text-gray">Need to open a ticket?</span>
+      {#each recentReturnedTags as tag (tag)}
+        <a
+          class="w3-button w3-small w3-border w3-round w3-margin-left"
+          href={`/tickets/new/device/${tag}`}
+          on:click={l(`/tickets/new/device/${tag}`)}
+        >
+          Open a ticket about {tag}
+        </a>
+      {/each}
+    </div>
+  {/if}
   {#if checkedOut.length}
     Send Message:
     <MessageSender signoutItem={checkedOut[0]} />

--- a/src/ui/tickets/TicketBrowser.svelte
+++ b/src/ui/tickets/TicketBrowser.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { get } from "svelte/store";
   import { getTickets, ticketsStore, type Ticket } from "@data/tickets";
+  import { assetStore, searchForAsset } from "@data/inventory";
   import AssetDisplay from "@assets/AssetDisplay.svelte";
   import StudentTag from "@people/students/StudentTag.svelte";
   import TicketWorkflow from "./TicketWorkflow.svelte";
   import type { HistoryEntry } from "./history";
   import { showToast } from "@ui/components/toastStore";
   import Loader from "@components/Loader.svelte";
+
+  // When set (via /tickets/new/device/:tag) open a fresh draft ticket with
+  // this device already assigned, e.g. from the check-in screen.
+  export let newDeviceTag: string = "";
 
   let loading = true;
   let error: string | null = null;
@@ -106,7 +112,24 @@
       error = err.message || "Failed to load tickets";
       loading = false;
     }
+    if (newDeviceTag) {
+      await openDraftForDevice(newDeviceTag);
+    }
   });
+
+  async function openDraftForDevice(tag: string) {
+    let asset: any = get(assetStore)[tag];
+    if (!asset) {
+      try {
+        // searchForAsset populates assetStore (keyed by Asset Tag); read back
+        await searchForAsset(tag);
+        asset = get(assetStore)[tag] || null;
+      } catch (e) {
+        // fall through — we'll still open a draft, just without the device
+      }
+    }
+    createTempTicket(asset);
+  }
 
   function showTicketDetail(ticket: Ticket) {
     selectedTicket = ticket;
@@ -134,7 +157,7 @@
 
   let currentTempTicketId: string | null = null;
 
-  function createTempTicket() {
+  function createTempTicket(device: any = null) {
     const tempId = `TEMP-${Date.now()}`;
     const created = new Date().toISOString();
     const temp: any = {
@@ -146,13 +169,23 @@
       History: JSON.stringify({ entries: [] }),
     };
 
+    // Pre-assign the device when opened from a check-in shortcut
+    if (device && device._id) {
+      temp.Device = [device._id];
+      temp.FormAsset = device["Asset Tag"] || "";
+      temp._linked = { Device: device };
+    }
+
     // push into local store for immediate visibility
     ticketsStore.update(($s: any) => {
       $s[tempId] = temp;
       return $s;
     });
     currentTempTicketId = tempId;
-    showToast("Draft ticket created", "info");
+    showToast(
+      device ? `Draft ticket for ${device["Asset Tag"]}` : "Draft ticket created",
+      "info"
+    );
     showTicketDetail(temp);
   }
 
@@ -240,7 +273,7 @@
   >
     <h2>Tickets</h2>
     <div style="display:flex; gap:8px;">
-      <button class="w3-button w3-green" on:click={createTempTicket}>
+      <button class="w3-button w3-green" on:click={() => createTempTicket()}>
         New
       </button>
     </div>

--- a/src/ui/tickets/TicketBrowser.svelte
+++ b/src/ui/tickets/TicketBrowser.svelte
@@ -118,12 +118,18 @@
   });
 
   async function openDraftForDevice(tag: string) {
-    let asset: any = get(assetStore)[tag];
+    // assetStore is keyed by the canonical (uppercase) Asset Tag, but the URL
+    // param may be any case, so normalize before the store lookup.
+    const canonical = (tag || "").toUpperCase();
+    let asset: any = get(assetStore)[canonical] || get(assetStore)[tag];
     if (!asset) {
       try {
-        // searchForAsset populates assetStore (keyed by Asset Tag); read back
-        await searchForAsset(tag);
-        asset = get(assetStore)[tag] || null;
+        const results = await searchForAsset(tag);
+        // searchForAsset also indexes the store by record id, which avoids
+        // any remaining case mismatch on the Asset Tag.
+        const rec = results && results[0];
+        asset =
+          (rec && get(assetStore)[rec.id]) || get(assetStore)[canonical] || null;
       } catch (e) {
         // fall through — we'll still open a draft, just without the device
       }


### PR DESCRIPTION
Handles the common loaner-swap case: a student with a machine in repair gets a flaky temp, returns it, and gets a different temp.

- Check IN a device that's an open ticket's Temporary Device: a pre-checked "Remove X as temp device on Ticket #N" box clears the link and sets Temp Status to "Needed" (student still needs a loaner).
- Check OUT a single device to a student with open ticket(s): offer to link it as that ticket's temp device (dropdown when multiple tickets). Defaults checked when the device's Purpose is "Temp"; a user override sticks. Sets Temp Status to "Loaned".
- After a return, an "Open a ticket about X" button deep-links to a new draft ticket with the device pre-assigned via /tickets/new/device/:tag (new TicketBrowser route + prefill).

Ticket mutations live in src/data/tempDevice.ts with history entries.