### PR TITLE
Pre-check repair pick-list from a ticket's saved items

### DIFF
--- a/src/ui/tickets/components/RepairPickList.svelte
+++ b/src/ui/tickets/components/RepairPickList.svelte
@@ -22,10 +22,26 @@
 
   export let onSelect: (items: RepairItem[]) => void = () => {};
   export let disabled: boolean = false;
+  // Labels already on the ticket (e.g. parsed from saved notes) so the
+  // checkboxes reflect existing repair items when a ticket is reopened.
+  export let initialLabels: string[] = [];
 
   let selectedItems: boolean[] = new Array(items.length).fill(false);
   let expanded = false;
   let containerEl: HTMLElement;
+
+  // Initialize (or re-initialize) checkboxes from initialLabels whenever they
+  // change to a new set — i.e. a different ticket loads or one is saved. Guard
+  // on a sorted signature so the user's in-progress toggles aren't clobbered,
+  // and do NOT call onSelect here (these items are already on the ticket).
+  let lastInitSig: string | null = null;
+  $: {
+    const sig = [...initialLabels].sort().join("|");
+    if (sig !== lastInitSig) {
+      lastInitSig = sig;
+      selectedItems = items.map((it) => initialLabels.includes(it.label));
+    }
+  }
 
   function handleSelectionChange() {
     onSelect(items.filter((_, index) => selectedItems[index]));

--- a/src/ui/tickets/steps/RepairWorkflow.svelte
+++ b/src/ui/tickets/steps/RepairWorkflow.svelte
@@ -177,6 +177,14 @@
     const current = (mergedTicket as any)["Repair Cost"];
   }
 
+  // Repair labels already saved on the ticket, so the pick-list pre-checks
+  // them. Sourced from the saved `ticket` (not the draft) so it stays stable
+  // while the user toggles items and only changes when a ticket loads/saves.
+  $: savedRepairLabels = ((ticket as any)?.Notes || "")
+    .split(/\r?\n/)
+    .filter((line: string) => line.startsWith("Repair Item:"))
+    .map((line: string) => line.replace(/^Repair Item:\s*/, "").trim());
+
   function handleRepairPick(items: { label: string; amount: number }[]) {
     // Calculate total cost from all selected items
     const totalCost = items.reduce((sum, item) => sum + item.amount, 0);
@@ -259,7 +267,11 @@
       {saving ? "Saving..." : "Save"}
     </button>
     <div style="display:flex;align-items:start;gap:8px" class="w3-small">
-      <RepairPickList onSelect={handleRepairPick} disabled={saving} />
+      <RepairPickList
+        onSelect={handleRepairPick}
+        initialLabels={savedRepairLabels}
+        disabled={saving}
+      />
       <div>
         <label for="repair-cost-input" class="w3-text-blue"
           ><b>Repair Cost</b></label


### PR DESCRIPTION
## Problem
The redesigned multi-select repair pick-list (#16) always started with every checkbox unchecked. Reopening a ticket that already had repair items didn't reflect them, so the closed control showed "Add repair items…" even though the ticket had a repair cost and `Repair Item:` notes.

## Fix
- `RepairWorkflow` parses the **saved** ticket's `Repair Item:` note lines into labels (`savedRepairLabels`) and passes them to `RepairPickList` as a new `initialLabels` prop. Sourced from `ticket` (not the draft) so it stays stable while the user toggles.
- `RepairPickList` initializes its checkboxes from `initialLabels`, guarded on a sorted signature so it only (re)initializes when a different ticket loads or one is saved — never clobbering in-progress toggles. It does **not** call `onSelect` on init, so opening a ticket doesn't dirty the draft or change the saved cost.

## Notes
- No change to the `onSelect(items[])` contract or `handleRepairPick`.
- Pre-existing behavior unchanged: a custom `Repair Item:` line whose label isn't in the hardcoded list still won't pre-check (and is rewritten away on the next toggle). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)