### PR TITLE
Show "repairing for" vs "signed out to" on device lookup

### DIFF
--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -6,10 +6,15 @@
   export let asset: Asset | null = null;
   export let showOwner: boolean = false;
   export let openInNewTab: boolean = false;
+  // Latest signout-record status (e.g. "Out", "Repairing") when the caller has
+  // it. Lets us show "repairing for" instead of "signed out to" for a device
+  // that's on the repair bench but still assigned to its student.
+  export let signoutStatus: string = "";
   $: assetTag = (asset && asset["Asset Tag"]) || "";
   $: purpose = asset?.Purpose || null;
   $: isRetired = purpose === "Disposed" || purpose === "Retired";
   $: isLost = asset?.Status === "Lost";
+  $: isRepairing = signoutStatus === "Repairing" && !isLost;
 </script>
 
 {#if !asset || !assetTag}
@@ -42,6 +47,8 @@
         <PurposeBadge {purpose} compact={true} />
         {#if isLost}
           <span class="w3-tag w3-red w3-round lost-badge">LOST</span>
+        {:else if isRepairing}
+          <span class="w3-tag w3-amber w3-round repair-badge">IN REPAIR</span>
         {/if}
       </div>
       <div class="limit w3-tiny">
@@ -58,7 +65,13 @@
       {#if showOwner}
         <div class="w3-small">
           {#if asset["Email (from Student (Current))"]}
-            {isLost ? "Lost — last signed out to" : "Currently signed out to"}
+            {#if isLost}
+              Lost — last signed out to
+            {:else if isRepairing}
+              Currently <em class="repairing-word">repairing</em> for
+            {:else}
+              Currently signed out to
+            {/if}
             <b class:inactive={asset["Student Status"]?.[0] === "Inactive"}>
               <EmailDisplay email={asset["Email (from Student (Current))"]} />
             </b>
@@ -124,9 +137,14 @@
     border: 2px dashed currentColor !important;
     background: transparent !important;
   }
-  .lost-badge {
+  .lost-badge,
+  .repair-badge {
     font-size: 0.8em;
     font-weight: bold;
     margin-left: 4px;
+  }
+  .repairing-word {
+    font-style: italic;
+    font-weight: bold;
   }
 </style>

--- a/src/ui/assets/LookupAsset.svelte
+++ b/src/ui/assets/LookupAsset.svelte
@@ -63,6 +63,10 @@
     }
   }
 
+  // Status of the most recent signout record (history is sorted Num desc), so
+  // AssetDisplay can show "repairing for" vs "signed out to".
+  $: currentSignoutStatus = (history[0] && history[0].Status) || "";
+
   let googleChromebookInfo: ChromebookInfo | null;
 
   async function getGoogleInfo() {
@@ -154,7 +158,7 @@
     </FormField>
   </SimpleForm>
   {#if asset}
-    <AssetDisplay {asset} showOwner={true} />
+    <AssetDisplay {asset} showOwner={true} signoutStatus={currentSignoutStatus} />
     <div class="w3-bar w3-row w3-border-bottom w3-medium">
       <button
         class="w3-button w3-bar-item"


### PR DESCRIPTION
## Context
A device that's in for repair correctly stays assigned to its student — that attachment is a feature (desk-scan safety so you don't re-issue someone else's machine, and "who has a device out" reports). But the device lookup showed `Currently signed out to alison@…` with no indication it was on the repair bench, which read as if the student still physically had it.

## Change
Purely a display fix — no data or workflow change.
- `AssetDisplay` takes an optional `signoutStatus` prop. When it's `"Repairing"`, the owner line reads `Currently repairing for <student>` and an amber `IN REPAIR` badge shows next to the model (parallel to the existing `LOST` badge).
- `LookupAsset` passes the most recent signout record's `Status` (history is already loaded and sorted).
- Other `AssetDisplay` callers are unaffected (prop defaults to `""` → unchanged "signed out to" text).

## Follow-up (not in this PR)
The check-in screen (`Checkout`) shows the same owner line when you scan a device but doesn't load per-asset signout status, so it'd need a small fetch to show the badge there too. Happy to add it if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)