### PR TITLE
Flag in-repair devices as "in our hands" across views

### DIFF
--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -203,12 +203,15 @@ export async function getStudentLoans(
   yog?: string,
   studentStatus?: string
 ) {
+  // No Purpose filter: a device in for repair has its Purpose flipped to
+  // "In for repairs", so filtering Purpose="Student Loan" would drop it from
+  // the report. "Has a current student" (studentLoan) is the real definition
+  // of a student loan; narrow by Purpose via the report's filter if needed.
   return await fetchReport({
     chromebookOnly,
     studentLoan: true,
     yog,
     studentStatus,
-    purpose: "Student Loan",
   });
 }
 

--- a/src/data/signoutHistory.ts
+++ b/src/data/signoutHistory.ts
@@ -35,12 +35,14 @@ export async function lookupSignoutHistory({
   staff,
   isLatest,
   onlyOut,
+  status,
 }: {
   asset?: Asset;
   student?: Student;
   staff?: Staff;
   isLatest?: boolean;
   onlyOut?: boolean;
+  status?: string;
 } = {}): Promise<SignoutHistoryEntry[]> {
   let params: Record<string, string> = { mode: "signoutHistory" };
   if (asset) {
@@ -55,6 +57,9 @@ export async function lookupSignoutHistory({
   if (isLatest) {
     params.isLatest = "true";
   }
+  if (status) {
+    params.status = status;
+  }
   if (staff) {
     params.staffId = staff._id;
   }
@@ -62,6 +67,33 @@ export async function lookupSignoutHistory({
   let response = await fetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   return json.map((item) => ({ ...item.fields, _id: item.id }));
+}
+
+// Cache of asset tags whose latest signout record is "Repairing" — i.e. the
+// device is physically in our hands for repair even though it stays assigned
+// to its student. One bulk query powers the "IN REPAIR" indicator across the
+// asset lookup, student loans, reports, and check-in scan.
+let repairingTagsCache: Set<string> | null = null;
+
+export async function getRepairingAssetTags(
+  force = false
+): Promise<Set<string>> {
+  if (repairingTagsCache && !force) return repairingTagsCache;
+  const records = await lookupSignoutHistory({
+    isLatest: true,
+    status: "Repairing",
+  });
+  const tags = new Set<string>();
+  for (const r of records) {
+    const tag = r["Asset Tag (from Asset)"]?.[0];
+    if (tag) tags.add(tag);
+  }
+  repairingTagsCache = tags;
+  return tags;
+}
+
+export function clearRepairingTagsCache() {
+  repairingTagsCache = null;
 }
 
 export let fetching = writable(false);

--- a/src/data/signoutHistory.ts
+++ b/src/data/signoutHistory.ts
@@ -96,6 +96,31 @@ export function clearRepairingTagsCache() {
   repairingTagsCache = null;
 }
 
+// Map of asset tag -> its latest signout status ("Out", "Repairing",
+// "Returned", "Lost", ...). The most recent signout record is the source of
+// truth for who holds a device and whether it's actually out with a student
+// vs. in our hands. One bulk query; used by the loan report to distinguish
+// "actually out" from "in for repair" regardless of Purpose.
+let latestStatusCache: Map<string, string> | null = null;
+
+export async function getLatestSignoutStatusByTag(
+  force = false
+): Promise<Map<string, string>> {
+  if (latestStatusCache && !force) return latestStatusCache;
+  const records = await lookupSignoutHistory({ isLatest: true });
+  const map = new Map<string, string>();
+  for (const r of records) {
+    const tag = r["Asset Tag (from Asset)"]?.[0];
+    if (tag) map.set(tag, r.Status);
+  }
+  latestStatusCache = map;
+  return map;
+}
+
+export function clearLatestStatusCache() {
+  latestStatusCache = null;
+}
+
 export let fetching = writable(false);
 export let fullHistory: Writable<SignoutHistoryEntry[]> = writable([]);
 

--- a/src/functions/signoutHistory.ts
+++ b/src/functions/signoutHistory.ts
@@ -2,7 +2,7 @@ import type { APIGatewayEvent, Context } from "aws-lambda";
 import { signoutHistoryBase } from "./Airtable";
 
 export async function handler(event: APIGatewayEvent, context: Context) {
-  const { assetTag, lasid, staffId, isLatest, onlyOut } =
+  const { assetTag, lasid, staffId, isLatest, onlyOut, status } =
     event.queryStringParameters;
   let filterByFormula = "";
   if (assetTag) {
@@ -16,6 +16,14 @@ export async function handler(event: APIGatewayEvent, context: Context) {
   }
   if (onlyOut) {
     let andPart = '{Status}="Out"';
+    if (filterByFormula) {
+      filterByFormula = `and(${filterByFormula},${andPart})`;
+    } else {
+      filterByFormula = andPart;
+    }
+  }
+  if (status) {
+    let andPart = `{Status}="${status}"`;
     if (filterByFormula) {
       filterByFormula = `and(${filterByFormula},${andPart})`;
     } else {

--- a/src/ui/assets/AssetDisplay.svelte
+++ b/src/ui/assets/AssetDisplay.svelte
@@ -6,10 +6,15 @@
   export let asset: Asset | null = null;
   export let showOwner: boolean = false;
   export let openInNewTab: boolean = false;
+  // Latest signout-record status (e.g. "Out", "Repairing") when the caller has
+  // it. Lets us show "repairing for" instead of "signed out to" for a device
+  // that's on the repair bench but still assigned to its student.
+  export let signoutStatus: string = "";
   $: assetTag = (asset && asset["Asset Tag"]) || "";
   $: purpose = asset?.Purpose || null;
   $: isRetired = purpose === "Disposed" || purpose === "Retired";
   $: isLost = asset?.Status === "Lost";
+  $: isRepairing = signoutStatus === "Repairing" && !isLost;
 </script>
 
 {#if !asset || !assetTag}
@@ -42,6 +47,8 @@
         <PurposeBadge {purpose} compact={true} />
         {#if isLost}
           <span class="w3-tag w3-red w3-round lost-badge">LOST</span>
+        {:else if isRepairing}
+          <span class="w3-tag w3-amber w3-round repair-badge">IN REPAIR</span>
         {/if}
       </div>
       <div class="limit w3-tiny">
@@ -58,7 +65,13 @@
       {#if showOwner}
         <div class="w3-small">
           {#if asset["Email (from Student (Current))"]}
-            {isLost ? "Lost — last signed out to" : "Currently signed out to"}
+            {#if isLost}
+              Lost — last signed out to
+            {:else if isRepairing}
+              Currently <em class="repairing-word">repairing</em> for
+            {:else}
+              Currently signed out to
+            {/if}
             <b class:inactive={asset["Student Status"]?.[0] === "Inactive"}>
               <EmailDisplay email={asset["Email (from Student (Current))"]} />
             </b>
@@ -124,9 +137,14 @@
     border: 2px dashed currentColor !important;
     background: transparent !important;
   }
-  .lost-badge {
+  .lost-badge,
+  .repair-badge {
     font-size: 0.8em;
     font-weight: bold;
     margin-left: 4px;
+  }
+  .repairing-word {
+    font-style: italic;
+    font-weight: bold;
   }
 </style>

--- a/src/ui/assets/Checkout.svelte
+++ b/src/ui/assets/Checkout.svelte
@@ -736,7 +736,12 @@ Hinge bolts:New screws needed for display hinges*/
             <div in:fade|local class="w3-deep-orange w3-card w3-container">
               <h3>Student already has loans out:</h3>
               {#each currentLoans as loan}
-                <AssetDisplay asset={loan} />
+                <AssetDisplay
+                  asset={loan}
+                  signoutStatus={repairingTags.has(loan["Asset Tag"])
+                    ? "Repairing"
+                    : ""}
+                />
               {/each}
             </div>
           {/if}

--- a/src/ui/assets/Checkout.svelte
+++ b/src/ui/assets/Checkout.svelte
@@ -17,6 +17,7 @@
   import { l, withLoadingIndicator } from "@utils/util";
   import type { CheckoutStatus } from "@data/signout";
   import { signoutAsset } from "@data/signout";
+  import { getRepairingAssetTags } from "@data/signoutHistory";
   import { addStudentNote, getStudent } from "@data/students";
   import { assetStore } from "@data/inventory";
   import { staffStore } from "@data/staff";
@@ -78,6 +79,8 @@
     studentName: false,
   });
 
+  let repairingTags: Set<string> = new Set();
+
   onMount(async () => {
     if (lostTag) {
       $assetTags = [lostTag];
@@ -86,6 +89,13 @@
     logger.logVerbose("Fetch contacts!");
     await getContacts();
     logger.logVerbose($contactStore);
+    // So a scanned device that's in for repair shows "IN REPAIR" rather than
+    // reading as a normal loan — avoids re-issuing a device we already hold.
+    try {
+      repairingTags = await getRepairingAssetTags();
+    } catch (e) {
+      logger.logError("Failed to load in-repair devices:", e);
+    }
   });
 
   let validators = () => ({
@@ -797,7 +807,13 @@ Hinge bolts:New screws needed for display hinges*/
         {#each assets as asset, i}
           <div in:fade|local out:fade|local>
             {#if asset}
-              <AssetDisplay {asset} showOwner={true} />
+              <AssetDisplay
+                {asset}
+                showOwner={true}
+                signoutStatus={repairingTags.has(asset["Asset Tag"])
+                  ? "Repairing"
+                  : ""}
+              />
             {:else if $validating.assetTag}
               <Loader working={true} text="Finding asset..." />
             {:else if $assetTags[i].length > 3}

--- a/src/ui/assets/LookupAsset.svelte
+++ b/src/ui/assets/LookupAsset.svelte
@@ -63,6 +63,10 @@
     }
   }
 
+  // Status of the most recent signout record (history is sorted Num desc), so
+  // AssetDisplay can show "repairing for" vs "signed out to".
+  $: currentSignoutStatus = (history[0] && history[0].Status) || "";
+
   let googleChromebookInfo: ChromebookInfo | null;
 
   async function getGoogleInfo() {
@@ -154,7 +158,7 @@
     </FormField>
   </SimpleForm>
   {#if asset}
-    <AssetDisplay {asset} showOwner={true} />
+    <AssetDisplay {asset} showOwner={true} signoutStatus={currentSignoutStatus} />
     <div class="w3-bar w3-row w3-border-bottom w3-medium">
       <button
         class="w3-button w3-bar-item"

--- a/src/ui/people/students/LookupStudent.svelte
+++ b/src/ui/people/students/LookupStudent.svelte
@@ -14,7 +14,10 @@
   import NameDropdown from "@people/components/NameDropdown.svelte";
   import { getStudent, studentsStore } from "@data/students";
   import { getCurrentLoansForStudent } from "@data/inventory";
-  import { lookupSignoutHistory } from "@data/signoutHistory";
+  import {
+    lookupSignoutHistory,
+    getRepairingAssetTags,
+  } from "@data/signoutHistory";
   import MessageSender from "@notifications/MessageSender.svelte";
   import StudentGoogleAdminHistory from "@googleAdmin/StudentGoogleAdminHistory.svelte";
   import StudentTicketsTab from "./StudentTicketsTab.svelte";
@@ -49,11 +52,13 @@
   let loansLoaded = false;
   let loadingLoans = false;
   let lastLoansStudentId: string | null = null;
+  let repairingTags: Set<string> = new Set();
   async function ensureLoansLoaded() {
     if (!student || loansLoaded || loadingLoans) return;
     loadingLoans = true;
     try {
       current = await getCurrentLoansForStudent(student);
+      repairingTags = await getRepairingAssetTags();
       await loadSignoutHistory();
       loansLoaded = true;
     } finally {
@@ -165,16 +170,26 @@
             </p>
           {:else}
             {#each current as asset (asset["Asset Tag"])}
+              {@const inRepair = repairingTags.has(asset["Asset Tag"])}
               <div class="current-loan">
-                <AssetDisplay {asset} />
-                <a
-                  class="w3-small"
-                  href={`/checkout/lost/${asset["Asset Tag"]}`}
-                  on:click={l(`/checkout/lost/${asset["Asset Tag"]}`)}
-                  title="Open the check-in screen with this device pre-filled and 'Mark as Lost' selected"
-                >
-                  Device missing? Mark as lost &amp; bill family…
-                </a>
+                <AssetDisplay
+                  {asset}
+                  signoutStatus={inRepair ? "Repairing" : ""}
+                />
+                {#if inRepair}
+                  <span class="w3-small w3-text-amber"
+                    >In for repair — currently in our hands.</span
+                  >
+                {:else}
+                  <a
+                    class="w3-small"
+                    href={`/checkout/lost/${asset["Asset Tag"]}`}
+                    on:click={l(`/checkout/lost/${asset["Asset Tag"]}`)}
+                    title="Open the check-in screen with this device pre-filled and 'Mark as Lost' selected"
+                  >
+                    Device missing? Mark as lost &amp; bill family…
+                  </a>
+                {/if}
               </div>
             {:else}
               No current loans

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -17,11 +17,11 @@
   export let columns = [];
   export let filename = "data.csv";
   export let openAssetLinksInNewTab = false;
-  // Asset tags currently in for repair (in our hands, latest signout =
-  // "Repairing"). Used to flag rows and offer a repair-status filter.
-  export let repairingTags = new Set();
-  // "all" | "exclude" (hide in-repair) | "only" (just in-repair)
-  let repairFilter = "all";
+  // Map of asset tag -> latest checkout status ("Out", "Repairing", ...).
+  // The last checkout is the source of truth for who actually holds a device.
+  export let statusByTag = new Map();
+  // "all" | "out" (actually out with a student) | "repair" (in our hands)
+  let checkoutFilter = "all";
   // sortColumn is now a property name (string)
   let sortColumn = columns[0] || "";
   let sortDirection = "asc";
@@ -235,10 +235,10 @@
       !selectedPurposes.has(row.Purpose)
     )
       return false;
-    if (repairFilter !== "all") {
-      const inRepair = repairingTags.has(row["Asset Tag"]);
-      if (repairFilter === "exclude" && inRepair) return false;
-      if (repairFilter === "only" && !inRepair) return false;
+    if (checkoutFilter !== "all") {
+      const st = statusByTag.get(row["Asset Tag"]);
+      if (checkoutFilter === "out" && st !== "Out") return false;
+      if (checkoutFilter === "repair" && st !== "Repairing") return false;
     }
     return true;
   });
@@ -470,19 +470,19 @@
         {/if}
       </div>
     </div>
-    {#if repairingTags.size}
+    {#if statusByTag.size}
       <label
         class="w3-bar-item"
-        title="Devices in for repair are physically in our hands, though still assigned to their student."
-        >In repair:
+        title="Based on each device's last checkout action — the source of truth for who actually holds it. 'In for repair' means it's in our hands though still assigned to the student."
+        >Show:
         <select
-          bind:value={repairFilter}
+          bind:value={checkoutFilter}
           class="w3-select w3-border"
           style="width:auto;display:inline-block;margin-left:4px;"
         >
-          <option value="all">Include</option>
-          <option value="exclude">Exclude (in our hands)</option>
-          <option value="only">Only in-repair</option>
+          <option value="all">All assigned</option>
+          <option value="out">Actually out (with student)</option>
+          <option value="repair">In for repair (in our hands)</option>
         </select>
       </label>
     {/if}
@@ -610,13 +610,18 @@
 <div class="w3-responsive">
   <p>
     Showing <b>{filteredData.length}</b> records
-    {#if repairingTags.size}
-      {@const shownInRepair = filteredData.filter((r) =>
-        repairingTags.has(r["Asset Tag"]),
+    {#if statusByTag.size}
+      {@const shownOut = filteredData.filter(
+        (r) => statusByTag.get(r["Asset Tag"]) === "Out",
       ).length}
-      <span class="w3-text-amber"
-        >· {shownInRepair} in repair (of {repairingTags.size} total in our
-        hands)</span
+      {@const shownRepair = filteredData.filter(
+        (r) => statusByTag.get(r["Asset Tag"]) === "Repairing",
+      ).length}
+      <span class="w3-small w3-text-grey"
+        >· <b>{shownOut}</b> actually out
+        {#if shownRepair}· <span class="w3-text-amber"
+            ><b>{shownRepair}</b> in for repair (in our hands)</span
+          >{/if}</span
       >
     {/if}
   </p>
@@ -761,9 +766,7 @@
                   <AssetDisplay
                     asset={row}
                     openInNewTab={openAssetLinksInNewTab}
-                    signoutStatus={repairingTags.has(row["Asset Tag"])
-                      ? "Repairing"
-                      : ""}
+                    signoutStatus={statusByTag.get(row["Asset Tag"]) || ""}
                   />
                 {:else}
                   {row[column]}

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -608,7 +608,18 @@
   </div>
 {/if}
 <div class="w3-responsive">
-  <p>Showing <b>{filteredData.length}</b> records</p>
+  <p>
+    Showing <b>{filteredData.length}</b> records
+    {#if repairingTags.size}
+      {@const shownInRepair = filteredData.filter((r) =>
+        repairingTags.has(r["Asset Tag"]),
+      ).length}
+      <span class="w3-text-amber"
+        >· {shownInRepair} in repair (of {repairingTags.size} total in our
+        hands)</span
+      >
+    {/if}
+  </p>
 
   <div
     class="w3-bar w3-center w3-margin-bottom"

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -17,6 +17,11 @@
   export let columns = [];
   export let filename = "data.csv";
   export let openAssetLinksInNewTab = false;
+  // Asset tags currently in for repair (in our hands, latest signout =
+  // "Repairing"). Used to flag rows and offer a repair-status filter.
+  export let repairingTags = new Set();
+  // "all" | "exclude" (hide in-repair) | "only" (just in-repair)
+  let repairFilter = "all";
   // sortColumn is now a property name (string)
   let sortColumn = columns[0] || "";
   let sortDirection = "asc";
@@ -230,6 +235,11 @@
       !selectedPurposes.has(row.Purpose)
     )
       return false;
+    if (repairFilter !== "all") {
+      const inRepair = repairingTags.has(row["Asset Tag"]);
+      if (repairFilter === "exclude" && inRepair) return false;
+      if (repairFilter === "only" && !inRepair) return false;
+    }
     return true;
   });
 
@@ -460,6 +470,22 @@
         {/if}
       </div>
     </div>
+    {#if repairingTags.size}
+      <label
+        class="w3-bar-item"
+        title="Devices in for repair are physically in our hands, though still assigned to their student."
+        >In repair:
+        <select
+          bind:value={repairFilter}
+          class="w3-select w3-border"
+          style="width:auto;display:inline-block;margin-left:4px;"
+        >
+          <option value="all">Include</option>
+          <option value="exclude">Exclude (in our hands)</option>
+          <option value="only">Only in-repair</option>
+        </select>
+      </label>
+    {/if}
     <div class="dropdown-filter" style="position:relative;">
       <button
         class="w3-button w3-border w3-bar-item"
@@ -724,6 +750,9 @@
                   <AssetDisplay
                     asset={row}
                     openInNewTab={openAssetLinksInNewTab}
+                    signoutStatus={repairingTags.has(row["Asset Tag"])
+                      ? "Repairing"
+                      : ""}
                   />
                 {:else}
                   {row[column]}

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -104,8 +104,8 @@
     return new Date(lastUsed) < thirtyDaysAgo;
   }
   function resortData(data, direction, prop) {
-    sortedData = [...data]; // Create a copy...
-    sortedData.sort((a, b) => {
+    const sorted = [...data]; // Create a copy...
+    sorted.sort((a, b) => {
       let sortProp = prop;
       if (prop === "_ASSET") {
         sortProp = "Asset Tag";
@@ -132,9 +132,14 @@
       }
       return 0;
     });
+    return sorted;
   }
 
-  $: resortData(data, sortDirection, sortColumn);
+  // Derived (not a side-effect assignment) so Svelte orders the chain
+  // data -> sortedData -> filteredData and recomputes filteredData when the
+  // report data first arrives — otherwise the table stays empty until some
+  // other state change forces a re-flush.
+  $: sortedData = resortData(data, sortDirection, sortColumn);
 
   let haveGoogleData = false;
   $: {

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -225,12 +225,18 @@
       if (filterStale === FILTER_TRUE && !isStale(row.lastUsed)) return false;
       if (filterStale === FILTER_FALSE && isStale(row.lastUsed)) return false;
     }
+    // Only filter when SOME (not all, not zero) are selected. size === 0 is
+    // the transient pre-init state (and a deliberate "None" click) — treating
+    // it as "no filter" stops the table rendering empty until a filter is
+    // touched.
     if (
+      selectedModels.size > 0 &&
       selectedModels.size < uniqueModels.length &&
       !selectedModels.has(row.Model)
     )
       return false;
     if (
+      selectedPurposes.size > 0 &&
       selectedPurposes.size < uniquePurposes.length &&
       !selectedPurposes.has(row.Purpose)
     )

--- a/src/ui/reports/Reports.svelte
+++ b/src/ui/reports/Reports.svelte
@@ -26,7 +26,7 @@
   import ReportTable from "./ReportTable.svelte";
   import Loader from "@components/Loader.svelte";
   import StudentDeviceReport from "./StudentDeviceReport.svelte";
-  import { getRepairingAssetTags } from "@data/signoutHistory";
+  import { getLatestSignoutStatusByTag } from "@data/signoutHistory";
 
   let activeTab:
     | "studentLoans"
@@ -45,13 +45,14 @@
   // Add filtering by Student Status
   let selectedStudentStatus: string | null = null; // New variable for Student Status
   let reportRun = false;
-  let repairingTags: Set<string> = new Set();
+  let statusByTag: Map<string, string> = new Map();
   // Ensure YOG filtering is applied when fetching student loans
   async function fetchData() {
     loading = true;
     reportRun = false;
-    // Refresh which devices are currently in for repair (in our hands)
-    repairingTags = await getRepairingAssetTags(true);
+    // Latest checkout status per device — the source of truth for who holds
+    // each machine (actually out vs. in our hands for repair).
+    statusByTag = await getLatestSignoutStatusByTag(true);
     if (activeTab === "studentLoans") {
       studentLoans = await normalizeAssets(
         await getStudentLoans(true, selectedYOG, selectedStudentStatus), // Pass Student Status
@@ -306,7 +307,7 @@
           {columns}
           {headers}
           {filename}
-          {repairingTags}
+          {statusByTag}
           openAssetLinksInNewTab={true}
         />
       {/if}

--- a/src/ui/reports/Reports.svelte
+++ b/src/ui/reports/Reports.svelte
@@ -26,6 +26,7 @@
   import ReportTable from "./ReportTable.svelte";
   import Loader from "@components/Loader.svelte";
   import StudentDeviceReport from "./StudentDeviceReport.svelte";
+  import { getRepairingAssetTags } from "@data/signoutHistory";
 
   let activeTab:
     | "studentLoans"
@@ -44,10 +45,13 @@
   // Add filtering by Student Status
   let selectedStudentStatus: string | null = null; // New variable for Student Status
   let reportRun = false;
+  let repairingTags: Set<string> = new Set();
   // Ensure YOG filtering is applied when fetching student loans
   async function fetchData() {
     loading = true;
     reportRun = false;
+    // Refresh which devices are currently in for repair (in our hands)
+    repairingTags = await getRepairingAssetTags(true);
     if (activeTab === "studentLoans") {
       studentLoans = await normalizeAssets(
         await getStudentLoans(true, selectedYOG, selectedStudentStatus), // Pass Student Status
@@ -302,6 +306,7 @@
           {columns}
           {headers}
           {filename}
+          {repairingTags}
           openAssetLinksInNewTab={true}
         />
       {/if}

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -12,6 +12,9 @@
   } from "@data/studentDeviceReport";
   import { INACTIVE_PURPOSES } from "@data/inventory";
   import PurposeBadge from "@assets/PurposeBadge.svelte";
+  import { getRepairingAssetTags } from "@data/signoutHistory";
+
+  let repairingTags: Set<string> = new Set();
 
   type SortColumn =
     | "student"
@@ -422,6 +425,7 @@
     progress = { completed: 0, total: 0 };
 
     try {
+      repairingTags = await getRepairingAssetTags(true);
       rows = await buildStudentDeviceReport({
         yog: inputMode === "yog" ? selectedYOG.trim() : undefined,
         emails: inputMode === "list" ? parsedEmails : undefined,
@@ -793,6 +797,11 @@
                           asset={displayRow.machine.asset}
                           openInNewTab={true}
                           showOwner={true}
+                          signoutStatus={repairingTags.has(
+                            displayRow.machine.assetTag,
+                          )
+                            ? "Repairing"
+                            : ""}
                         />
                       {:else}
                         <div>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -69,6 +69,8 @@
   let sortDirection: "asc" | "desc" = "desc";
   let selectedStatuses: Set<string> = new Set();
   let hideRetired = true;
+  // "all" | "exclude" (hide in-repair) | "only"
+  let repairFilter: "all" | "exclude" | "only" = "all";
   let expandedMachines = {};
   let tableScrollEl: HTMLDivElement | null = null;
   let topScrollEl: HTMLDivElement | null = null;
@@ -96,6 +98,8 @@
     hideRetired,
     sortColumn,
     sortDirection,
+    repairFilter,
+    repairingTags,
   );
   $: exportRows = exportFromDisplayRows(displayRows);
   $: filename = [
@@ -380,10 +384,20 @@
     hideInactive: boolean,
     column: SortColumn,
     direction: "asc" | "desc",
+    repair: "all" | "exclude" | "only" = "all",
+    repairing: Set<string> = new Set(),
   ) {
     const filtered = reportRows.filter((displayRow) => {
       if (!matchesStatusFilter(displayRow, selected)) return false;
       if (hideInactive && displayRow.machine?.purpose && INACTIVE_PURPOSES.includes(displayRow.machine.purpose)) return false;
+      if (repair !== "all") {
+        const inRepair = !!(
+          displayRow.machine?.assetTag &&
+          repairing.has(displayRow.machine.assetTag)
+        );
+        if (repair === "exclude" && inRepair) return false;
+        if (repair === "only" && !inRepair) return false;
+      }
       return true;
     });
 
@@ -657,6 +671,20 @@
       <label class="retired-toggle">
         <input type="checkbox" bind:checked={hideRetired} />
         Hide Disposed/Retired machines
+      </label>
+    {/if}
+
+    {#if rows.length && repairingTags.size}
+      <label
+        class="retired-toggle"
+        title="Devices in for repair are physically in our hands, though still assigned to their student."
+      >
+        In repair:
+        <select bind:value={repairFilter}>
+          <option value="all">Include</option>
+          <option value="exclude">Exclude (in our hands)</option>
+          <option value="only">Only in-repair</option>
+        </select>
       </label>
     {/if}
 


### PR DESCRIPTION
Builds on #23 (merged in here so this previews standalone — merge #23 first, or merge this and it carries both).

## Why
A device in for repair stays assigned to its student on purpose (desk-scan safety + "who has a device out" reports). But student loans, reports, and the check-in scan all read that as a normal active loan, so it's not clear the device is physically on our bench.

## What
- **Shared signal:** `getRepairingAssetTags()` runs one signout-history query (`isLatest` + new `status=Repairing` backend filter) and returns the set of asset tags whose latest record is `Repairing`, cached per run. No per-device queries.
- **Student lookup → Current Loans:** in-repair devices get the `IN REPAIR` badge + "in for repair — currently in our hands" and the "Device missing? Mark as lost" prompt is hidden (we have it, it's not missing).
- **Reports:** in-repair rows are flagged, plus an **In repair** filter (Include / Exclude / Only) so "which devices are we trying to track down" can drop the ones already in for repair. Default = Include (nothing hidden unless you choose).
- **Check-in scan:** a scanned in-repair device shows the badge, so you don't re-issue something we already hold.

## Notes
- Display/query only — no change to how devices are signed out or assigned.
- `ReportTable.svelte` is a plain-JS component, so its new props are untyped (no TS annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)