### PR TITLE
Add serial number fallback to asset tag lookup

### DIFF
--- a/src/ui/assets/Checkout.svelte
+++ b/src/ui/assets/Checkout.svelte
@@ -160,7 +160,9 @@
   );
   $: student = studentMode && getStudent($studentName);
   $: staff = !studentMode && $staffStore[$staffName];
-  $: assets = $assetTags.map((assetTag) => $assetStore[assetTag.toUpperCase()]);
+  $: assets = $assetTags.map(
+    (t) => $assetStore[t.toUpperCase()] || $assetStore[t.toLowerCase()]
+  );
   /* $: charger = $assetStore[$chargerTag]; */
 
   let checkedOut: {
@@ -750,7 +752,7 @@ Hinge bolts:New screws needed for display hinges*/
           id="assettag"
           type="text"
           class="w3-input"
-          placeholder="Asset Tag"
+          placeholder="Asset tag or serial number"
           autocomplete="off"
         />
       </FormField>

--- a/src/ui/assets/LookupAsset.svelte
+++ b/src/ui/assets/LookupAsset.svelte
@@ -145,6 +145,7 @@
         id="assettag"
         bind:value={$assetTag}
         class:valid={$lookupForm?.valid}
+        placeholder="Asset tag or serial number"
       />
       {#if $validatingAsset && $assetTag.length > 3}
         <Loader working={true} text="Looking up asset..." />

--- a/src/ui/utils/validators.ts
+++ b/src/ui/utils/validators.ts
@@ -208,6 +208,10 @@ export const validateAsset = async (
     }
     let valid = false;
     let results = await searchForAsset(s);
+    if (results.length === 0) {
+      // Fallback: try serial number lookup (kids sometimes rip off asset tags)
+      results = await searchForAsset(null, null, s.toLowerCase());
+    }
     if (results.length) {
       valid = true;
     }


### PR DESCRIPTION
## Summary

- `validateAsset()` in `validators.ts` now falls back to a serial number search when the asset tag search returns no results — same API call, just passes the input as `serial` instead of `tag`
- Single serial match auto-resolves to the asset tag, so the rest of the UI populates exactly as if you'd typed the tag
- `LookupAsset.svelte` input now shows "Asset tag or serial number" placeholder

## Test plan

- [ ] Type a known asset tag — works as before
- [ ] Type a serial number for a device — resolves to the correct asset and populates device details
- [ ] Type a serial number in the Checkout view — same behavior
- [ ] Type a bogus string — still shows "No asset found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)