### PR TITLE
Chromebook disable/enable via Google Admin API

### DIFF
--- a/gas/Code.js
+++ b/gas/Code.js
@@ -13,10 +13,9 @@ function makeResult (e, object) {
   return ContentService.createTextOutput(
     JSON.stringify({
       status : 'success',
-      parameters: e.parameters,
       result : object
     })
-  )
+  ).setMimeType(ContentService.MimeType.JSON);
 }
 
 function makeErrorMessage (e, details={}) {
@@ -24,17 +23,18 @@ function makeErrorMessage (e, details={}) {
       JSON.stringify(
         {
           status : 'Error',
-          parameters : e.parameters,
           ...details}
         )
-  )
+  ).setMimeType(ContentService.MimeType.JSON);
 }
 
 function doGet (e) {
   // Provide a Web API for getting Chromebook info
   if (e.parameters.secret != getSecret()) {
     // Ensure they have provided our SECRET! Top SECRET SECURITY! ;-\
-    return ContentService.createTextOutput("no access, sorry -- you don't know the secret!");
+    return ContentService.createTextOutput(
+      JSON.stringify({ status: 'Error', detail: 'Unauthorized' })
+    ).setMimeType(ContentService.MimeType.JSON);
   }
   // Parameters are provided as lists, annoyingly... make a simplified object for convenience
   let params = {};
@@ -120,7 +120,7 @@ function doGet (e) {
 
 function cbBySerial (id) {
   let resp = AdminDirectory.Chromeosdevices.list("my_customer",{query:`id:"${id.toLowerCase()}"`});
-  if (resp && resp.chromeosdevices.length) {
+  if (resp && resp.chromeosdevices && resp.chromeosdevices.length) {
     if (resp.chromeosdevices.length > 1) {
       console.warn('Strange: we got more than one hit for a serial number???',id,resp.chromeosdevices.length,resp.chromeosdevices);
     }

--- a/gas/Code.js
+++ b/gas/Code.js
@@ -79,11 +79,39 @@ function doGet (e) {
         );
       }
     }
+  } else if (params.mode === 'action') {
+    // Action mode: disable or reenable a device by serial number
+    // ?secret=SECRET&mode=action&serial=5CD119166D&action=disable|reenable
+    const allowed = ['disable', 'reenable'];
+    if (!params.serial) {
+      return makeErrorMessage(e, { detail: 'No serial provided with mode=action' });
+    }
+    if (!allowed.includes(params.action)) {
+      return makeErrorMessage(e, { detail: `Invalid action "${params.action}": expected disable or reenable` });
+    }
+    try {
+      const device = cbBySerial(params.serial);
+      if (!device) {
+        return makeErrorMessage(e, { detail: `Device not found for serial: ${params.serial}` });
+      }
+      AdminDirectory.Chromeosdevices.action(
+        { action: params.action },
+        'my_customer',
+        device.deviceId
+      );
+      return makeResult(e, { deviceId: device.deviceId, serial: params.serial, action: params.action });
+    } catch (error) {
+      return makeErrorMessage(e, {
+        detail: `Error performing ${params.action}`,
+        errorMessage: error.message || String(error),
+        errorStack: error.stack || null
+      });
+    }
   } else {
     // Error if no mode= provided
-    return makeErrorMessage(e,{
-        detail : 'Unknown mode: expected mode="serial" or mode="user"'
-      });    
+    return makeErrorMessage(e, {
+      detail: 'Unknown mode: expected mode="serial", mode="user", or mode="action"'
+    });
   }
 }
 
@@ -113,6 +141,36 @@ function testCbBySerial () {
   let id = "5CD042L0ZS";
   console.log('Testing CB by Serial with',id);
   console.log(cbBySerial(id));
+}
+
+function testDisable () {
+  let serial = "5CD119166D"; // ACTIVE device
+  console.log('Looking up device by serial:', serial);
+  const device = cbBySerial(serial);
+  console.log('Found device:', device && device.deviceId, 'status:', device && device.status);
+  console.log('Attempting disable...');
+  AdminDirectory.Chromeosdevices.action(
+    { action: 'disable' },
+    'my_customer',
+    device.deviceId
+  );
+  console.log('Done — checking new status:');
+  console.log(cbBySerial(serial).status);
+}
+
+function testReenable () {
+  let serial = "5CD119166D"; // should be DISABLED after testDisable
+  console.log('Looking up device by serial:', serial);
+  const device = cbBySerial(serial);
+  console.log('Found device:', device && device.deviceId, 'status:', device && device.status);
+  console.log('Attempting reenable...');
+  AdminDirectory.Chromeosdevices.action(
+    { action: 'reenable' },
+    'my_customer',
+    device.deviceId
+  );
+  console.log('Done — checking new status:');
+  console.log(cbBySerial(serial).status);
 }
 
 

--- a/gas/appsscript.json
+++ b/gas/appsscript.json
@@ -9,6 +9,9 @@
       }
     ]
   },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/admin.directory.device.chromeos"
+  ],
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "webapp": {

--- a/src/data/google.ts
+++ b/src/data/google.ts
@@ -104,20 +104,27 @@ export async function setDeviceDisabled(
   asset: Asset,
   disabled: boolean
 ): Promise<{ success: boolean; errorMessage?: string }> {
-  const action = disabled ? "disable" : "reenable";
-  const response = await fetch(
-    "/.netlify/functions/index?mode=google&action=" +
-      action +
-      "&serial=" +
-      encodeURIComponent(asset.Serial)
-  );
-  const json = await response.json();
-  if (json.status === "success") {
-    // Invalidate cache so next fetch reflects new status
-    delete serialCache[asset.Serial];
-    return { success: true };
+  try {
+    const action = disabled ? "disable" : "reenable";
+    const response = await fetch(
+      "/.netlify/functions/index?mode=google&action=" +
+        action +
+        "&serial=" +
+        encodeURIComponent(asset.Serial)
+    );
+    if (!response.ok && response.status !== 500) {
+      return { success: false, errorMessage: `Server error: ${response.status}` };
+    }
+    const json = await response.json();
+    if (json.status === "success") {
+      // Invalidate cache so next fetch reflects new status
+      delete serialCache[asset.Serial];
+      return { success: true };
+    }
+    return { success: false, errorMessage: json.errorMessage || json.detail || "Unknown error" };
+  } catch (err) {
+    return { success: false, errorMessage: err instanceof Error ? err.message : String(err) };
   }
-  return { success: false, errorMessage: json.errorMessage || json.detail || "Unknown error" };
 }
 
 export async function checkMachineStatus(asset: Asset) {

--- a/src/data/google.ts
+++ b/src/data/google.ts
@@ -100,6 +100,26 @@ export async function getDevicesForUser(
   }
 }
 
+export async function setDeviceDisabled(
+  asset: Asset,
+  disabled: boolean
+): Promise<{ success: boolean; errorMessage?: string }> {
+  const action = disabled ? "disable" : "reenable";
+  const response = await fetch(
+    "/.netlify/functions/index?mode=google&action=" +
+      action +
+      "&serial=" +
+      encodeURIComponent(asset.Serial)
+  );
+  const json = await response.json();
+  if (json.status === "success") {
+    // Invalidate cache so next fetch reflects new status
+    delete serialCache[asset.Serial];
+    return { success: true };
+  }
+  return { success: false, errorMessage: json.errorMessage || json.detail || "Unknown error" };
+}
+
 export async function checkMachineStatus(asset: Asset) {
   const googleData = await getDeviceInfo(asset);
 

--- a/src/data/google.ts
+++ b/src/data/google.ts
@@ -106,7 +106,7 @@ export async function setDeviceDisabled(
 ): Promise<{ success: boolean; errorMessage?: string }> {
   try {
     const action = disabled ? "disable" : "reenable";
-    const response = await fetch(
+    const response = await authedFetch(
       "/.netlify/functions/index?mode=google&action=" +
         action +
         "&serial=" +

--- a/src/functions/googleAdmin.ts
+++ b/src/functions/googleAdmin.ts
@@ -3,43 +3,46 @@ import { getAuthLevel, forbidden } from "./auth";
 const SHIM_SECRET = process.env.SHIM_SECRET;
 const SHIM_URL = process.env.SHIM_URL;
 
+async function callShim(params: Record<string, string>) {
+  const response = await fetch(SHIM_URL + "?" + new URLSearchParams(params), {
+    method: "GET",
+    redirect: "follow",
+  });
+  return response.json();
+}
+
 export async function handler(event: APIGatewayEvent, context: Context) {
   console.log("Google Shim Handler");
+  if (!SHIM_SECRET || !SHIM_URL) {
+    return { statusCode: 500, body: JSON.stringify({ error: "Server misconfiguration: missing SHIM_SECRET or SHIM_URL" }) };
+  }
   if (event.httpMethod == "GET") {
     const { user, serial, action } = event.queryStringParameters || {};
-    // Device actions (disable/reenable) require IT-level access
-    if (action && getAuthLevel(context) !== "it") {
-      return forbidden("IT access required for device actions");
-    }
-    let params;
-    if (user) {
-      params = {
-        mode: "user",
-        secret: SHIM_SECRET,
-        user,
-      };
+    if (action) {
+      // Device actions (disable/reenable) require IT-level access
+      if (getAuthLevel(context) !== "it") {
+        return forbidden("IT access required for device actions");
+      }
+      if (!serial) {
+        return { statusCode: 400, body: JSON.stringify({ error: "serial required for action" }) };
+      }
+      if (action !== "disable" && action !== "reenable") {
+        return { statusCode: 400, body: JSON.stringify({ error: "action must be disable or reenable" }) };
+      }
+      const json = await callShim({ mode: "action", secret: SHIM_SECRET, serial, action });
+      const statusCode = json.status === "success" ? 200 : 500;
+      return { statusCode, body: JSON.stringify(json) };
+    } else if (user) {
+      const json = await callShim({ mode: "user", secret: SHIM_SECRET, user });
+      return { statusCode: 200, body: JSON.stringify(json) };
     } else if (serial) {
-      params = {
-        mode: "serial",
-        id: serial,
-        secret: SHIM_SECRET,
-      };
+      const json = await callShim({ mode: "serial", secret: SHIM_SECRET, id: serial });
+      return { statusCode: 200, body: JSON.stringify(json) };
     } else {
       return {
         statusCode: 400,
-        body: JSON.stringify({
-          error: `No user or serial provided`,
-          params: JSON.stringify(event.queryStringParameters),
-        }),
+        body: JSON.stringify({ error: "No user, serial, or action provided" }),
       };
     }
-    let response = await fetch(SHIM_URL + "?" + new URLSearchParams(params), {
-      method: "GET",
-      redirect: "follow",
-    });
-    return {
-      statusCode: 200,
-      body: JSON.stringify(await response.json()),
-    };
   }
 }

--- a/src/ui/assets/ChromebookInfoDisplay.svelte
+++ b/src/ui/assets/ChromebookInfoDisplay.svelte
@@ -51,12 +51,15 @@
     actionInProgress = true;
     actionError = "";
     const disabling = currentStatus === "ACTIVE";
-    const result = await setDeviceDisabled(asset, disabling);
-    actionInProgress = false;
-    if (result.success) {
-      currentStatus = disabling ? "DISABLED" : "ACTIVE";
-    } else {
-      actionError = result.errorMessage || "Action failed";
+    try {
+      const result = await setDeviceDisabled(asset, disabling);
+      if (result.success) {
+        currentStatus = disabling ? "DISABLED" : "ACTIVE";
+      } else {
+        actionError = result.errorMessage || "Action failed";
+      }
+    } finally {
+      actionInProgress = false;
     }
   }
 </script>

--- a/src/ui/assets/ChromebookInfoDisplay.svelte
+++ b/src/ui/assets/ChromebookInfoDisplay.svelte
@@ -2,11 +2,13 @@
   import { logger } from "@utils/log";
   import AssetDisplay from "./AssetDisplay.svelte";
   import type { ChromebookInfo } from "@data/google";
+  import { setDeviceDisabled } from "@data/google";
   import { assetStore, searchForAsset } from "@data/inventory";
   import type { Asset } from "@data/inventory";
 
   export let info: ChromebookInfo;
-  info.activeTimeRanges;
+
+  const ADMIN_CONSOLE_URL = "https://admin.google.com/ac/chrome/devices";
 
   function formatDuration(ms) {
     const totSeconds = ms / 1000;
@@ -26,6 +28,7 @@
       }
     }
   }
+
   let showAllUsers = false;
   let asset: Asset;
   if ($assetStore[info.serialNumber.toLowerCase()]) {
@@ -37,9 +40,41 @@
     });
   }
   let showChart = false;
+
+  // Disable/enable action state
+  let actionInProgress = false;
+  let actionError = "";
+  let currentStatus = info.status;
+
+  async function toggleDisabled() {
+    if (!asset) return;
+    actionInProgress = true;
+    actionError = "";
+    const disabling = currentStatus === "ACTIVE";
+    const result = await setDeviceDisabled(asset, disabling);
+    actionInProgress = false;
+    if (result.success) {
+      currentStatus = disabling ? "DISABLED" : "ACTIVE";
+    } else {
+      actionError = result.errorMessage || "Action failed";
+    }
+  }
 </script>
 
 <div class="w3-small w3-card w3-container">
+  <!-- Device status banner -->
+  {#if currentStatus === "DISABLED"}
+    <div class="w3-panel w3-red status-banner">
+      <strong>⚠ Device is DISABLED</strong> — shows a lock screen; cannot be used
+      by students.
+    </div>
+  {:else if currentStatus === "DEPROVISIONED"}
+    <div class="w3-panel w3-deep-purple w3-text-white status-banner">
+      <strong>Device is DEPROVISIONED</strong> — removed from management. Cannot
+      be re-enrolled without a license.
+    </div>
+  {/if}
+
   {#if info.recentUsers && info.activeTimeRanges}
     <h4 class="summary w3-medium">
       Last used by <b>{info.recentUsers[0].email}</b> on
@@ -47,6 +82,7 @@
     </h4>
     <div class="w3-tiny">According to Google Admin Data</div>
   {/if}
+
   <div class="w3-row">
     <div class="w3-col l8 m8 s12">
       s/n: {info.serialNumber}
@@ -64,6 +100,38 @@
       {#if asset}<AssetDisplay {asset} />{/if}
     </div>
   </div>
+
+  <!-- Disable / re-enable control -->
+  {#if asset && currentStatus !== "DEPROVISIONED"}
+    <div class="action-row">
+      {#if currentStatus === "DISABLED"}
+        <button
+          class="w3-button w3-green"
+          disabled={actionInProgress}
+          on:click={toggleDisabled}
+        >
+          {actionInProgress ? "Re-enabling…" : "Re-enable Device"}
+        </button>
+      {:else}
+        <button
+          class="w3-button w3-orange"
+          disabled={actionInProgress}
+          on:click={toggleDisabled}
+        >
+          {actionInProgress ? "Disabling…" : "Disable Device"}
+        </button>
+      {/if}
+      {#if actionError}
+        <span class="w3-text-red w3-small">
+          {actionError} —
+          <a href={ADMIN_CONSOLE_URL} target="_blank" rel="noopener"
+            >manage in Admin console</a
+          >
+        </span>
+      {/if}
+    </div>
+  {/if}
+
   <button
     class="w3-button"
     class:w3-blue={showChart}
@@ -117,5 +185,17 @@
   }
   .reverse li:last-child {
     border-bottom: 1px solid #ddd;
+  }
+  .status-banner {
+    margin: 8px 0;
+    padding: 8px 16px;
+    border-radius: 4px;
+  }
+  .action-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 8px 0;
+    flex-wrap: wrap;
   }
 </style>

--- a/src/ui/assets/ChromebookInfoDisplay.svelte
+++ b/src/ui/assets/ChromebookInfoDisplay.svelte
@@ -7,6 +7,7 @@
   import type { Asset } from "@data/inventory";
 
   export let info: ChromebookInfo;
+  export let isIt: boolean = false;
 
   const ADMIN_CONSOLE_URL = "https://admin.google.com/ac/chrome/devices";
 
@@ -45,6 +46,14 @@
   let actionInProgress = false;
   let actionError = "";
   let currentStatus = info.status;
+  let showDisableConfirm = false;
+
+  function openDisableConfirm() {
+    showDisableConfirm = true;
+  }
+  function cancelDisableConfirm() {
+    showDisableConfirm = false;
+  }
 
   async function toggleDisabled() {
     if (!asset) return;
@@ -104,8 +113,8 @@
     </div>
   </div>
 
-  <!-- Disable / re-enable control -->
-  {#if asset && currentStatus !== "DEPROVISIONED"}
+  <!-- Disable / re-enable control (IT staff only) -->
+  {#if isIt && asset && currentStatus !== "DEPROVISIONED"}
     <div class="action-row">
       {#if currentStatus === "DISABLED"}
         <button
@@ -119,7 +128,7 @@
         <button
           class="w3-button w3-orange"
           disabled={actionInProgress}
-          on:click={toggleDisabled}
+          on:click={openDisableConfirm}
         >
           {actionInProgress ? "Disabling…" : "Disable Device"}
         </button>
@@ -132,6 +141,25 @@
           >
         </span>
       {/if}
+    </div>
+  {/if}
+
+  <!-- Disable confirmation dialog -->
+  {#if showDisableConfirm}
+    <div class="confirm-overlay">
+      <div class="w3-card w3-padding confirm-dialog">
+        <h4>Disable this device?</h4>
+        <p class="w3-small">
+          The device will show a lock screen and <strong>cannot be used by students</strong> until re-enabled.
+          Use this if a machine is missing or was taken without authorization.
+        </p>
+        <div class="action-row">
+          <button class="w3-button w3-red" disabled={actionInProgress} on:click={() => { cancelDisableConfirm(); toggleDisabled(); }}>
+            {actionInProgress ? "Disabling…" : "Yes, disable it"}
+          </button>
+          <button class="w3-button w3-light-grey" on:click={cancelDisableConfirm}>Cancel</button>
+        </div>
+      </div>
     </div>
   {/if}
 
@@ -200,5 +228,19 @@
     gap: 12px;
     margin: 8px 0;
     flex-wrap: wrap;
+  }
+  .confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  .confirm-dialog {
+    background: white;
+    max-width: 400px;
+    width: 90%;
   }
 </style>

--- a/src/ui/assets/LookupAsset.svelte
+++ b/src/ui/assets/LookupAsset.svelte
@@ -20,6 +20,7 @@
   let validatingAsset = writable(false);
 
   export let tag;
+  export let isIt: boolean = false;
   $: if (tag) {
     $assetTag = tag;
   }
@@ -193,7 +194,7 @@
       {/if}
     {:else if mode == "google"}
       {#if googleChromebookInfo}
-        <ChromebookInfoDisplay info={googleChromebookInfo} />
+        <ChromebookInfoDisplay info={googleChromebookInfo} {isIt} />
       {:else}
         No google info found (yet)
       {/if}

--- a/src/ui/googleAdmin/StudentGoogleAdminHistory.svelte
+++ b/src/ui/googleAdmin/StudentGoogleAdminHistory.svelte
@@ -6,6 +6,7 @@
   import type { ChromebookInfo } from "@data/google";
   import { getDevicesForUser } from "@data/google";
   export let student: Student | Staff;
+  export let isIt: boolean = false;
   let lastLookedUp = null;
   let chromebooks: ChromebookInfo[] | void;
 
@@ -25,7 +26,7 @@
   <div class="w3-card w3-container">
     <h2>Student was last to use {chromebooks.length} Chromebooks</h2>
     {#each chromebooks as chromebook}
-      <ChromebookInfoDisplay info={chromebook} />
+      <ChromebookInfoDisplay info={chromebook} {isIt} />
     {/each}
   </div>
 {:else if student}

--- a/src/ui/people/staff/LookupStaff.svelte
+++ b/src/ui/people/staff/LookupStaff.svelte
@@ -20,6 +20,7 @@
   import StudentGoogleAdminHistory from "@googleAdmin/StudentGoogleAdminHistory.svelte";
 
   export let name = "";
+  export let isIt: boolean = false;
   if (name) {
     $staffName = name;
     logger.logVerbose("Got staff", $staffName, name);
@@ -185,7 +186,7 @@
       </div>
     </article>
     <article class="w3-card w3-cell-middle">
-      <StudentGoogleAdminHistory student={staff} />
+      <StudentGoogleAdminHistory student={staff} {isIt} />
     </article>
   </div>
 {/if}

--- a/src/ui/people/students/LookupStudent.svelte
+++ b/src/ui/people/students/LookupStudent.svelte
@@ -23,6 +23,7 @@
   import StudentTicketsTab from "./StudentTicketsTab.svelte";
   import Loader from "@components/Loader.svelte";
   export let name = "";
+  export let isIt: boolean = false;
   if (name) {
     $studentName = name;
     logger.logVerbose("LookupStudent got student", $studentName, name);
@@ -160,7 +161,7 @@
         >
       </nav>
       <div class="w3-container">
-        <StudentGoogleAdminHistory {student} active={activeTab === "google"} />
+        <StudentGoogleAdminHistory {student} {isIt} active={activeTab === "google"} />
         <StudentTicketsTab {student} active={activeTab === "tickets"} />
         {#if activeTab == "loans"}
           <h3>Current Loans:</h3>

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -447,29 +447,36 @@
     const succeeded = [];
     const failed = [];
     const disabling = pendingDeviceAction === "disable";
-    await Promise.all(
-      tags.map(async (tag) => {
-        const asset = data.find((row) => row["Asset Tag"] === tag);
-        if (!asset || !asset.Serial) {
-          failed.push({ tag, serial: asset?.Serial || "?", error: "No serial number on record" });
-          return;
-        }
-        const result = await setDeviceDisabled(asset, disabling);
-        if (result.success) {
-          succeeded.push(tag);
-        } else {
-          failed.push({ tag, serial: asset.Serial, error: result.errorMessage || "Unknown error" });
-        }
-      })
-    );
-    deviceActionInProgress = false;
-    deviceActionResults = { succeeded, failed, action: pendingDeviceAction };
-    if (failed.length === 0) {
-      showToast(
-        `${disabling ? "Disabled" : "Re-enabled"} ${succeeded.length} device(s)`,
-        "success"
+    try {
+      await Promise.all(
+        tags.map(async (tag) => {
+          const asset = data.find((row) => row["Asset Tag"] === tag);
+          if (!asset || !asset.Serial) {
+            failed.push({ tag, serial: asset?.Serial || "?", error: "No serial number on record" });
+            return;
+          }
+          try {
+            const result = await setDeviceDisabled(asset, disabling);
+            if (result.success) {
+              succeeded.push(tag);
+            } else {
+              failed.push({ tag, serial: asset.Serial, error: result.errorMessage || "Unknown error" });
+            }
+          } catch (err) {
+            failed.push({ tag, serial: asset.Serial, error: err.message || "Unknown error" });
+          }
+        })
       );
-      selectedAssetTags = new Set();
+    } finally {
+      deviceActionInProgress = false;
+      deviceActionResults = { succeeded, failed, action: pendingDeviceAction };
+      if (failed.length === 0) {
+        showToast(
+          `${disabling ? "Disabled" : "Re-enabled"} ${succeeded.length} device(s)`,
+          "success"
+        );
+        selectedAssetTags = new Set();
+      }
     }
   }
 

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -373,15 +373,17 @@
   async function confirmMarkSelectedAsLost() {
     isUpdatingStatus = true;
     updateStatusError = "";
+    const tags = [...selectedAssetTags];
+    const total = tags.length;
+    let completed = 0;
+    lostProgress = { completed: 0, total };
     try {
-      const tags = [...selectedAssetTags];
       const billingErrors = [];
       let billedCount = 0;
       await Promise.all(
         tags.map(async (tag) => {
           const asset = data.find((row) => row["Asset Tag"] === tag);
           if (!asset) throw new Error(`Asset not found: ${tag}`);
-          // Bill first so the signout note can record the ticket number.
           let note = lostNote;
           if (billForReplacement) {
             if (!getBillableStudentId(asset)) {
@@ -404,6 +406,11 @@
           }
           await signoutAsset(null, null, asset, note, "Lost", false);
           await updateAsset(asset._id, { Status: "Lost" });
+          // Optimistic UI: mark this tag locally without waiting for a full data reload
+          localLostTags.add(tag);
+          localLostTags = localLostTags;
+          completed++;
+          lostProgress = { completed, total };
         }),
       );
       if (billingErrors.length) {
@@ -418,8 +425,8 @@
             : `Marked ${tags.length} device(s) lost`,
           "success",
         );
-        selectedAssetTags = new Set();
         closeLostConfirm();
+        // Selection kept so user can chain actions (e.g. mark lost then disable)
       }
     } catch (e) {
       updateStatusError = e.message || "Failed to update status.";
@@ -430,9 +437,14 @@
 
   // Batch disable / enable
   let deviceActionInProgress = false;
+  let deviceActionProgress = { completed: 0, total: 0 };
   let deviceActionResults = null; // { succeeded, failed: [{tag, serial, error}], action }
   let showDeviceActionConfirm = false;
   let pendingDeviceAction = ""; // "disable" | "reenable"
+
+  // Local optimistic state
+  let localLostTags = new Set();
+  let lostProgress = { completed: 0, total: 0 };
 
   function openDeviceActionConfirm(action) {
     pendingDeviceAction = action;
@@ -447,12 +459,17 @@
     const succeeded = [];
     const failed = [];
     const disabling = pendingDeviceAction === "disable";
+    const total = tags.length;
+    let completed = 0;
+    deviceActionProgress = { completed: 0, total };
     try {
       await Promise.all(
         tags.map(async (tag) => {
           const asset = data.find((row) => row["Asset Tag"] === tag);
           if (!asset || !asset.Serial) {
             failed.push({ tag, serial: asset?.Serial || "?", error: "No serial number on record" });
+            completed++;
+            deviceActionProgress = { completed, total };
             return;
           }
           try {
@@ -465,6 +482,8 @@
           } catch (err) {
             failed.push({ tag, serial: asset.Serial, error: err.message || "Unknown error" });
           }
+          completed++;
+          deviceActionProgress = { completed, total };
         })
       );
     } finally {
@@ -475,7 +494,7 @@
           `${disabling ? "Disabled" : "Re-enabled"} ${succeeded.length} device(s)`,
           "success"
         );
-        selectedAssetTags = new Set();
+        // Selection kept intentionally — allows chaining actions on same set
       }
     }
   }
@@ -731,8 +750,8 @@
 
   <!-- Disable/enable confirmation dialog -->
   {#if showDeviceActionConfirm}
-    <div class="modal-wrap">
-      <div class="modal-content w3-card w3-padding">
+    <div class="modal-wrap" style="display:flex;align-items:center;justify-content:center;z-index:2000;">
+      <div class="modal-content lost-confirm-modal w3-card" style="max-width:440px;width:90vw;padding:2em;position:relative;">
         <h4>
           {pendingDeviceAction === "disable" ? "Disable" : "Re-enable"}
           {selectedAssetTags.size} device(s)?
@@ -762,6 +781,16 @@
           </button>
         </div>
       </div>
+    </div>
+  {/if}
+
+  <!-- Device action in-progress indicator -->
+  {#if deviceActionInProgress}
+    <div class="w3-container w3-pale-blue w3-border w3-margin-bottom">
+      <p>
+        {pendingDeviceAction === "disable" ? "Disabling" : "Re-enabling"} devices…
+        {deviceActionProgress.completed}/{deviceActionProgress.total} done
+      </p>
     </div>
   {/if}
 
@@ -915,6 +944,9 @@
                     openInNewTab={openAssetLinksInNewTab}
                     signoutStatus={statusByTag.get(row["Asset Tag"]) || ""}
                   />
+                  {#if localLostTags.has(row["Asset Tag"])}
+                    <span class="w3-tag w3-orange" style="font-size:10px;padding:1px 5px;margin-top:2px;display:inline-block;">Marked Lost</span>
+                  {/if}
                 {:else}
                   {row[column]}
                 {/if}
@@ -1026,8 +1058,8 @@
           >
             {isUpdatingStatus
               ? billForReplacement
-                ? "Marking lost & sending invoices..."
-                : "Marking as Lost..."
+                ? `Marking & invoicing… (${lostProgress.completed}/${lostProgress.total})`
+                : `Marking Lost… (${lostProgress.completed}/${lostProgress.total})`
               : billForReplacement
                 ? "Confirm & Send Invoice(s)"
                 : "Confirm"}

--- a/src/ui/reports/ReportTable.svelte
+++ b/src/ui/reports/ReportTable.svelte
@@ -11,7 +11,10 @@
     getBillableStudentId,
     DEFAULT_REPLACEMENT_COST,
   } from "@data/lostDeviceBilling";
+  import { setDeviceDisabled } from "@data/google";
   import { showToast } from "@components/toastStore";
+
+  const ADMIN_CONSOLE_URL = "https://admin.google.com/ac/chrome/devices";
 
   export let data;
   export let columns = [];
@@ -425,6 +428,51 @@
     }
   }
 
+  // Batch disable / enable
+  let deviceActionInProgress = false;
+  let deviceActionResults = null; // { succeeded, failed: [{tag, serial, error}], action }
+  let showDeviceActionConfirm = false;
+  let pendingDeviceAction = ""; // "disable" | "reenable"
+
+  function openDeviceActionConfirm(action) {
+    pendingDeviceAction = action;
+    showDeviceActionConfirm = true;
+  }
+
+  async function confirmDeviceAction() {
+    deviceActionInProgress = true;
+    showDeviceActionConfirm = false;
+    deviceActionResults = null;
+    const tags = [...selectedAssetTags];
+    const succeeded = [];
+    const failed = [];
+    const disabling = pendingDeviceAction === "disable";
+    await Promise.all(
+      tags.map(async (tag) => {
+        const asset = data.find((row) => row["Asset Tag"] === tag);
+        if (!asset || !asset.Serial) {
+          failed.push({ tag, serial: asset?.Serial || "?", error: "No serial number on record" });
+          return;
+        }
+        const result = await setDeviceDisabled(asset, disabling);
+        if (result.success) {
+          succeeded.push(tag);
+        } else {
+          failed.push({ tag, serial: asset.Serial, error: result.errorMessage || "Unknown error" });
+        }
+      })
+    );
+    deviceActionInProgress = false;
+    deviceActionResults = { succeeded, failed, action: pendingDeviceAction };
+    if (failed.length === 0) {
+      showToast(
+        `${disabling ? "Disabled" : "Re-enabled"} ${succeeded.length} device(s)`,
+        "success"
+      );
+      selectedAssetTags = new Set();
+    }
+  }
+
   export let loginDataReady = false;
 </script>
 
@@ -655,10 +703,91 @@
     >
       Mark as Lost
     </button>
+    <button
+      class="w3-button w3-red w3-bar-item"
+      disabled={selectedAssetTags.size === 0 || deviceActionInProgress}
+      on:click={() => openDeviceActionConfirm("disable")}
+    >
+      Disable Selected
+    </button>
+    <button
+      class="w3-button w3-green w3-bar-item"
+      disabled={selectedAssetTags.size === 0 || deviceActionInProgress}
+      on:click={() => openDeviceActionConfirm("reenable")}
+    >
+      Re-enable Selected
+    </button>
     <span class="w3-bar-item data-exporter-wrap" style="padding:0;">
       <DataExporter items={filteredData} {filename} headers={exportColumns} />
     </span>
   </div>
+
+  <!-- Disable/enable confirmation dialog -->
+  {#if showDeviceActionConfirm}
+    <div class="modal-wrap">
+      <div class="modal-content w3-card w3-padding">
+        <h4>
+          {pendingDeviceAction === "disable" ? "Disable" : "Re-enable"}
+          {selectedAssetTags.size} device(s)?
+        </h4>
+        {#if pendingDeviceAction === "disable"}
+          <p class="w3-small">
+            Disabled devices will show a lock screen and cannot be used until
+            re-enabled. This calls the Google Admin API.
+          </p>
+        {:else}
+          <p class="w3-small">
+            This will re-enable the selected devices via the Google Admin API.
+          </p>
+        {/if}
+        <div style="display:flex;gap:8px;margin-top:16px;">
+          <button
+            class="w3-button {pendingDeviceAction === 'disable' ? 'w3-red' : 'w3-green'}"
+            on:click={confirmDeviceAction}
+          >
+            Confirm {pendingDeviceAction === "disable" ? "Disable" : "Re-enable"}
+          </button>
+          <button
+            class="w3-button w3-light-grey"
+            on:click={() => (showDeviceActionConfirm = false)}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Device action results -->
+  {#if deviceActionResults}
+    <div class="w3-panel {deviceActionResults.failed.length ? 'w3-pale-red' : 'w3-pale-green'} w3-border">
+      <p>
+        <strong>
+          {deviceActionResults.action === "disable" ? "Disabled" : "Re-enabled"}
+          {deviceActionResults.succeeded.length} device(s).
+        </strong>
+        {#if deviceActionResults.failed.length}
+          {deviceActionResults.failed.length} failed:
+        {/if}
+      </p>
+      {#if deviceActionResults.failed.length}
+        <ul class="w3-ul w3-small">
+          {#each deviceActionResults.failed as f}
+            <li><b>{f.tag}</b> (s/n: {f.serial}) — {f.error}</li>
+          {/each}
+        </ul>
+        <p class="w3-small">
+          <a href={ADMIN_CONSOLE_URL} target="_blank" rel="noopener">
+            Manage these devices manually in the Google Admin console →
+          </a>
+        </p>
+      {/if}
+      <button
+        class="w3-button w3-tiny w3-light-grey"
+        on:click={() => (deviceActionResults = null)}>Dismiss</button
+      >
+    </div>
+  {/if}
 
   {#if mountBulkMessageSender}
     <div

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -131,6 +131,8 @@
     }
   }
 
+  export let isIt: boolean = false;
+
   let repairingTags: Set<string> = new Set();
 
   type SortColumn =
@@ -861,8 +863,8 @@
       <b>{exportRows.filter((row) => row.Serial).length}</b> last-used machines
     </p>
 
-    <!-- Batch action bar -->
-    {#if selectedSerials.size > 0}
+    <!-- Batch action bar (IT only) -->
+    {#if isIt && selectedSerials.size > 0}
       <div class="batch-action-bar w3-bar">
         <span class="w3-bar-item"><b>{selectedSerials.size}</b> device(s) selected</span>
         <button
@@ -968,14 +970,14 @@
         >
           <thead>
             <tr>
-              <th class="select-col">
+              {#if isIt}<th class="select-col">
                 <input
                   type="checkbox"
                   checked={selectableMachines.length > 0 && selectedSerials.size === selectableMachines.length}
                   indeterminate={selectedSerials.size > 0 && selectedSerials.size < selectableMachines.length}
                   on:change={toggleSelectAll}
                 />
-              </th>
+              </th>{/if}
               <th on:click={() => setSort("student")}>Student</th>
               <th on:click={() => setSort("status")}>Status</th>
               <th>Machine</th>
@@ -984,13 +986,13 @@
               <th>Checkout Status</th>
               <th on:click={() => setSort("summary")}>Summary</th>
               <th on:click={() => setSort("lastUsedMachineCount")}>Count</th>
-              <th>Admin</th>
+              {#if isIt}<th>Admin</th>{/if}
             </tr>
           </thead>
           <tbody>
             {#each displayRows as displayRow (displayRow.key)}
               <tr class:has-warning={isWarningMachine(displayRow.machine)}>
-                <td class="select-col">
+                {#if isIt}<td class="select-col">
                   {#if displayRow.machine && displayRow.machine.serial && displayRow.machine.asset}
                     <input
                       type="checkbox"
@@ -998,7 +1000,7 @@
                       on:change={() => toggleSelectMachine(displayRow.machine.serial)}
                     />
                   {/if}
-                </td>
+                </td>{/if}
                 <td>
                   <b><EmailDisplay email={displayRow.row.student.Email} /></b>
                   <div class="w3-small">{displayRow.row.student.Name}</div>
@@ -1091,7 +1093,7 @@
                   {/if}
                 </td>
                 <td>{formatCount(displayRow)}</td>
-                <td class="admin-cell">
+                {#if isIt}<td class="admin-cell">
                   {#if displayRow.machine && displayRow.machine.serial && displayRow.machine.asset}
                     {#if getAdminStatus(displayRow.machine) === "DEPROVISIONED"}
                       <span class="admin-badge deprovisioned">Deprovisioned</span>
@@ -1117,11 +1119,11 @@
                       </div>
                     {/if}
                   {/if}
-                </td>
+                </td>{/if}
               </tr>
               {#if expandedMachines[displayRow.key] && displayRow.machine}
                 <tr class="expanded-row">
-                  <td colspan="10">
+                  <td colspan={isIt ? 10 : 8}>
                     <div class="expanded-grid">
                       <div>
                         <h4>Recent Users</h4>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -36,17 +36,98 @@
       ...deviceActions,
       [serial]: { status: currentAdminStatus, inProgress: true, error: "" },
     };
-    const result = await setDeviceDisabled(asset, disabling);
-    if (result.success) {
-      deviceActions = {
-        ...deviceActions,
-        [serial]: { status: disabling ? "DISABLED" : "ACTIVE", inProgress: false, error: "" },
-      };
+    try {
+      const result = await setDeviceDisabled(asset, disabling);
+      if (result.success) {
+        deviceActions = {
+          ...deviceActions,
+          [serial]: { status: disabling ? "DISABLED" : "ACTIVE", inProgress: false, error: "" },
+        };
+      } else {
+        deviceActions = {
+          ...deviceActions,
+          [serial]: { status: currentAdminStatus, inProgress: false, error: result.errorMessage || "Action failed" },
+        };
+      }
+    } finally {
+      if (deviceActions[serial]?.inProgress) {
+        deviceActions = { ...deviceActions, [serial]: { ...deviceActions[serial], inProgress: false } };
+      }
+    }
+  }
+
+  // Batch selection state
+  let selectedSerials: Set<string> = new Set();
+  let showBatchActionConfirm = false;
+  let pendingBatchAction = "";
+  let batchActionInProgress = false;
+  let batchActionResults: { succeeded: string[]; failed: { serial: string; error: string }[]; action: string } | null = null;
+
+  $: selectableMachines = displayRows
+    .filter((dr) => dr.machine && dr.machine.serial && dr.machine.asset)
+    .map((dr) => dr.machine.serial);
+
+  function toggleSelectMachine(serial: string) {
+    if (selectedSerials.has(serial)) {
+      selectedSerials.delete(serial);
     } else {
-      deviceActions = {
-        ...deviceActions,
-        [serial]: { status: currentAdminStatus, inProgress: false, error: result.errorMessage || "Action failed" },
-      };
+      selectedSerials.add(serial);
+    }
+    selectedSerials = new Set(selectedSerials);
+  }
+
+  function toggleSelectAll() {
+    if (selectedSerials.size === selectableMachines.length) {
+      selectedSerials = new Set();
+    } else {
+      selectedSerials = new Set(selectableMachines);
+    }
+  }
+
+  function openBatchAction(action: string) {
+    pendingBatchAction = action;
+    showBatchActionConfirm = true;
+  }
+
+  async function confirmBatchDeviceAction() {
+    batchActionInProgress = true;
+    showBatchActionConfirm = false;
+    batchActionResults = null;
+    const serials = [...selectedSerials];
+    const succeeded: string[] = [];
+    const failed: { serial: string; error: string }[] = [];
+    const disabling = pendingBatchAction === "disable";
+    try {
+      await Promise.all(
+        serials.map(async (serial) => {
+          const dr = displayRows.find((d) => d.machine?.serial === serial);
+          const asset = dr?.machine?.asset;
+          if (!asset) {
+            failed.push({ serial, error: "Asset not found" });
+            return;
+          }
+          try {
+            const result = await setDeviceDisabled(asset, disabling);
+            if (result.success) {
+              succeeded.push(serial);
+              deviceActions = {
+                ...deviceActions,
+                [serial]: { status: disabling ? "DISABLED" : "ACTIVE", inProgress: false, error: "" },
+              };
+            } else {
+              failed.push({ serial, error: result.errorMessage || "Unknown error" });
+            }
+          } catch (err) {
+            failed.push({ serial, error: err instanceof Error ? err.message : "Unknown error" });
+          }
+        })
+      );
+    } finally {
+      batchActionInProgress = false;
+      batchActionResults = { succeeded, failed, action: pendingBatchAction };
+      if (failed.length === 0) {
+        selectedSerials = new Set();
+      }
     }
   }
 
@@ -780,6 +861,76 @@
       <b>{exportRows.filter((row) => row.Serial).length}</b> last-used machines
     </p>
 
+    <!-- Batch action bar -->
+    {#if selectedSerials.size > 0}
+      <div class="batch-action-bar w3-bar">
+        <span class="w3-bar-item"><b>{selectedSerials.size}</b> device(s) selected</span>
+        <button
+          class="w3-button w3-red w3-bar-item"
+          disabled={batchActionInProgress}
+          on:click={() => openBatchAction("disable")}
+        >Disable Selected</button>
+        <button
+          class="w3-button w3-green w3-bar-item"
+          disabled={batchActionInProgress}
+          on:click={() => openBatchAction("reenable")}
+        >Re-enable Selected</button>
+        <button
+          class="w3-button w3-light-grey w3-bar-item"
+          on:click={() => (selectedSerials = new Set())}
+        >Clear</button>
+      </div>
+    {/if}
+
+    <!-- Batch action confirm dialog -->
+    {#if showBatchActionConfirm}
+      <div class="modal-wrap">
+        <div class="modal-content w3-card w3-padding">
+          <h4>{pendingBatchAction === "disable" ? "Disable" : "Re-enable"} {selectedSerials.size} device(s)?</h4>
+          {#if pendingBatchAction === "disable"}
+            <p class="w3-small">Disabled devices will show a lock screen and cannot be used until re-enabled.</p>
+          {:else}
+            <p class="w3-small">This will re-enable the selected devices via the Google Admin API.</p>
+          {/if}
+          <div style="display:flex;gap:8px;margin-top:16px;">
+            <button
+              class="w3-button {pendingBatchAction === 'disable' ? 'w3-red' : 'w3-green'}"
+              on:click={confirmBatchDeviceAction}
+            >Confirm {pendingBatchAction === "disable" ? "Disable" : "Re-enable"}</button>
+            <button class="w3-button w3-light-grey" on:click={() => (showBatchActionConfirm = false)}>Cancel</button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Batch action results -->
+    {#if batchActionResults}
+      <div class="w3-panel {batchActionResults.failed.length ? 'w3-pale-red' : 'w3-pale-green'} w3-border">
+        <p>
+          <strong>
+            {batchActionResults.action === "disable" ? "Disabled" : "Re-enabled"}
+            {batchActionResults.succeeded.length} device(s).
+          </strong>
+          {#if batchActionResults.failed.length}
+            {batchActionResults.failed.length} failed:
+          {/if}
+        </p>
+        {#if batchActionResults.failed.length}
+          <ul class="w3-ul w3-small">
+            {#each batchActionResults.failed as f}
+              <li><b>{f.serial}</b> — {f.error}</li>
+            {/each}
+          </ul>
+          <p class="w3-small">
+            <a href={ADMIN_CONSOLE_URL} target="_blank" rel="noopener">
+              Manage these devices manually in the Google Admin console →
+            </a>
+          </p>
+        {/if}
+        <button class="w3-button w3-tiny w3-light-grey" on:click={() => (batchActionResults = null)}>Dismiss</button>
+      </div>
+    {/if}
+
     <div class="w3-responsive">
       {#if showViewportScroll}
         <div
@@ -817,6 +968,14 @@
         >
           <thead>
             <tr>
+              <th class="select-col">
+                <input
+                  type="checkbox"
+                  checked={selectableMachines.length > 0 && selectedSerials.size === selectableMachines.length}
+                  indeterminate={selectedSerials.size > 0 && selectedSerials.size < selectableMachines.length}
+                  on:change={toggleSelectAll}
+                />
+              </th>
               <th on:click={() => setSort("student")}>Student</th>
               <th on:click={() => setSort("status")}>Status</th>
               <th>Machine</th>
@@ -831,6 +990,15 @@
           <tbody>
             {#each displayRows as displayRow (displayRow.key)}
               <tr class:has-warning={isWarningMachine(displayRow.machine)}>
+                <td class="select-col">
+                  {#if displayRow.machine && displayRow.machine.serial && displayRow.machine.asset}
+                    <input
+                      type="checkbox"
+                      checked={selectedSerials.has(displayRow.machine.serial)}
+                      on:change={() => toggleSelectMachine(displayRow.machine.serial)}
+                    />
+                  {/if}
+                </td>
                 <td>
                   <b><EmailDisplay email={displayRow.row.student.Email} /></b>
                   <div class="w3-small">{displayRow.row.student.Name}</div>
@@ -953,7 +1121,7 @@
               </tr>
               {#if expandedMachines[displayRow.key] && displayRow.machine}
                 <tr class="expanded-row">
-                  <td colspan="9">
+                  <td colspan="10">
                     <div class="expanded-grid">
                       <div>
                         <h4>Recent Users</h4>
@@ -1196,5 +1364,31 @@
     margin-top: 2px;
     padding: 2px 8px !important;
     font-size: 11px !important;
+  }
+  .select-col {
+    width: 32px;
+    text-align: center;
+    vertical-align: middle;
+  }
+  .batch-action-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+    flex-wrap: wrap;
+  }
+  .modal-wrap {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  .modal-content {
+    background: white;
+    max-width: 480px;
+    width: 90%;
   }
 </style>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -990,18 +990,16 @@
         <button class="w3-button w3-orange w3-bar-item" disabled={isUpdatingLostStatus} on:click={openLostConfirm}>
           Mark as Lost
         </button>
-        {#if isIt}
-          <button
-            class="w3-button w3-red w3-bar-item"
-            disabled={batchActionInProgress}
-            on:click={() => openBatchAction("disable")}
-          >Disable Selected</button>
-          <button
-            class="w3-button w3-green w3-bar-item"
-            disabled={batchActionInProgress}
-            on:click={() => openBatchAction("reenable")}
-          >Re-enable Selected</button>
-        {/if}
+        <button
+          class="w3-button w3-red w3-bar-item"
+          disabled={batchActionInProgress}
+          on:click={() => openBatchAction("disable")}
+        >Disable Selected</button>
+        <button
+          class="w3-button w3-green w3-bar-item"
+          disabled={batchActionInProgress}
+          on:click={() => openBatchAction("reenable")}
+        >Re-enable Selected</button>
         <button
           class="w3-button w3-light-grey w3-bar-item"
           on:click={() => (selectedSerials = new Set())}

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -13,6 +13,42 @@
   import { INACTIVE_PURPOSES } from "@data/inventory";
   import PurposeBadge from "@assets/PurposeBadge.svelte";
   import { getRepairingAssetTags } from "@data/signoutHistory";
+  import { setDeviceDisabled } from "@data/google";
+
+  const ADMIN_CONSOLE_URL = "https://admin.google.com/ac/chrome/devices";
+
+  type DeviceActionState = {
+    status: string;
+    inProgress: boolean;
+    error: string;
+  };
+  let deviceActions: Record<string, DeviceActionState> = {};
+
+  function getAdminStatus(machine: StudentDeviceReportMachine | null): string | null {
+    if (!machine?.serial) return null;
+    return deviceActions[machine.serial]?.status ?? machine.googleData?.status ?? null;
+  }
+
+  async function toggleDeviceDisabled(serial: string, asset, currentAdminStatus: string) {
+    if (!serial || !asset) return;
+    const disabling = currentAdminStatus === "ACTIVE";
+    deviceActions = {
+      ...deviceActions,
+      [serial]: { status: currentAdminStatus, inProgress: true, error: "" },
+    };
+    const result = await setDeviceDisabled(asset, disabling);
+    if (result.success) {
+      deviceActions = {
+        ...deviceActions,
+        [serial]: { status: disabling ? "DISABLED" : "ACTIVE", inProgress: false, error: "" },
+      };
+    } else {
+      deviceActions = {
+        ...deviceActions,
+        [serial]: { status: currentAdminStatus, inProgress: false, error: result.errorMessage || "Action failed" },
+      };
+    }
+  }
 
   let repairingTags: Set<string> = new Set();
 
@@ -789,6 +825,7 @@
               <th>Checkout Status</th>
               <th on:click={() => setSort("summary")}>Summary</th>
               <th on:click={() => setSort("lastUsedMachineCount")}>Count</th>
+              <th>Admin</th>
             </tr>
           </thead>
           <tbody>
@@ -886,10 +923,37 @@
                   {/if}
                 </td>
                 <td>{formatCount(displayRow)}</td>
+                <td class="admin-cell">
+                  {#if displayRow.machine && displayRow.machine.serial && displayRow.machine.asset}
+                    {#if getAdminStatus(displayRow.machine) === "DEPROVISIONED"}
+                      <span class="admin-badge deprovisioned">Deprovisioned</span>
+                    {:else if getAdminStatus(displayRow.machine) === "DISABLED"}
+                      <span class="admin-badge disabled">DISABLED</span>
+                      <button
+                        class="w3-button w3-green w3-tiny admin-action-btn"
+                        disabled={deviceActions[displayRow.machine.serial]?.inProgress}
+                        on:click={() => toggleDeviceDisabled(displayRow.machine.serial, displayRow.machine.asset, getAdminStatus(displayRow.machine))}
+                      >{deviceActions[displayRow.machine.serial]?.inProgress ? "…" : "Re-enable"}</button>
+                    {:else if getAdminStatus(displayRow.machine) === "ACTIVE"}
+                      <button
+                        class="w3-button w3-orange w3-tiny admin-action-btn"
+                        disabled={deviceActions[displayRow.machine.serial]?.inProgress}
+                        on:click={() => toggleDeviceDisabled(displayRow.machine.serial, displayRow.machine.asset, getAdminStatus(displayRow.machine))}
+                      >{deviceActions[displayRow.machine.serial]?.inProgress ? "…" : "Disable"}</button>
+                    {:else if getAdminStatus(displayRow.machine)}
+                      <span class="w3-small w3-text-gray">{getAdminStatus(displayRow.machine)}</span>
+                    {/if}
+                    {#if deviceActions[displayRow.machine.serial]?.error}
+                      <div class="w3-small w3-text-red">
+                        {deviceActions[displayRow.machine.serial].error} — <a href={ADMIN_CONSOLE_URL} target="_blank" rel="noopener">Admin console</a>
+                      </div>
+                    {/if}
+                  {/if}
+                </td>
               </tr>
               {#if expandedMachines[displayRow.key] && displayRow.machine}
                 <tr class="expanded-row">
-                  <td colspan="8">
+                  <td colspan="9">
                     <div class="expanded-grid">
                       <div>
                         <h4>Recent Users</h4>
@@ -1106,5 +1170,31 @@
     font-weight: normal;
     cursor: pointer;
     min-width: unset;
+  }
+  .admin-cell {
+    white-space: nowrap;
+    vertical-align: top;
+  }
+  .admin-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 2px 5px;
+    border-radius: 3px;
+    margin-bottom: 2px;
+  }
+  .admin-badge.disabled {
+    background: #ffcccc;
+    color: #8b0000;
+  }
+  .admin-badge.deprovisioned {
+    background: #e0d0f0;
+    color: #4a0072;
+  }
+  .admin-action-btn {
+    display: block;
+    margin-top: 2px;
+    padding: 2px 8px !important;
+    font-size: 11px !important;
   }
 </style>

--- a/src/ui/reports/StudentDeviceReport.svelte
+++ b/src/ui/reports/StudentDeviceReport.svelte
@@ -10,10 +10,14 @@
     type StudentDeviceReportMachine,
     type StudentDeviceReportRow,
   } from "@data/studentDeviceReport";
-  import { INACTIVE_PURPOSES } from "@data/inventory";
+  import { INACTIVE_PURPOSES, updateAsset } from "@data/inventory";
   import PurposeBadge from "@assets/PurposeBadge.svelte";
   import { getRepairingAssetTags } from "@data/signoutHistory";
   import { setDeviceDisabled } from "@data/google";
+  import { signoutAsset } from "@data/signout";
+  import { billForLostDevice, getBillableStudentId, DEFAULT_REPLACEMENT_COST } from "@data/lostDeviceBilling";
+  import { showToast } from "@components/toastStore";
+  import BulkMessageSender from "@notifications/BulkMessageSender.svelte";
 
   const ADMIN_CONSOLE_URL = "https://admin.google.com/ac/chrome/devices";
 
@@ -61,11 +65,38 @@
   let showBatchActionConfirm = false;
   let pendingBatchAction = "";
   let batchActionInProgress = false;
+  let batchActionProgress = { completed: 0, total: 0 };
   let batchActionResults: { succeeded: string[]; failed: { serial: string; error: string }[]; action: string } | null = null;
+
+  // Local optimistic state
+  let localLostSerials: Set<string> = new Set();
+
+  // Lost device flow
+  let showLostConfirm = false;
+  let lostNote = "";
+  let billForReplacement = false;
+  let replacementCost = DEFAULT_REPLACEMENT_COST;
+  let isUpdatingLostStatus = false;
+  let lostProgress = { completed: 0, total: 0 };
+  let updateLostError = "";
+
+  // Bulk message sender
+  let showBulkMessageSender = false;
+  let mountBulkMessageSender = false;
 
   $: selectableMachines = displayRows
     .filter((dr) => dr.machine && dr.machine.serial && dr.machine.asset)
     .map((dr) => dr.machine.serial);
+
+  $: selectedAssets = [...selectedSerials]
+    .map((serial) => displayRows.find((d) => d.machine?.serial === serial)?.machine?.asset)
+    .filter(Boolean);
+
+  $: selectedAssetTagsForEmail = [...selectedSerials]
+    .map((serial) => displayRows.find((d) => d.machine?.serial === serial)?.machine?.assetTag)
+    .filter(Boolean);
+
+  $: billableSelectedCount = selectedAssets.filter((asset) => getBillableStudentId(asset)).length;
 
   function toggleSelectMachine(serial: string) {
     if (selectedSerials.has(serial)) {
@@ -89,6 +120,81 @@
     showBatchActionConfirm = true;
   }
 
+  function openLostConfirm() {
+    lostNote = "";
+    billForReplacement = false;
+    replacementCost = DEFAULT_REPLACEMENT_COST;
+    updateLostError = "";
+    showLostConfirm = true;
+  }
+  function closeLostConfirm() {
+    showLostConfirm = false;
+  }
+
+  async function confirmMarkSelectedAsLost() {
+    isUpdatingLostStatus = true;
+    updateLostError = "";
+    const total = selectedAssets.length;
+    let completed = 0;
+    lostProgress = { completed: 0, total };
+    try {
+      const billingErrors: string[] = [];
+      let billedCount = 0;
+      await Promise.all(
+        selectedAssets.map(async (asset) => {
+          const tag = asset["Asset Tag"];
+          let note = lostNote;
+          if (billForReplacement) {
+            if (!getBillableStudentId(asset)) {
+              billingErrors.push(`${tag}: no current student to bill`);
+            } else {
+              try {
+                const { ticket } = await billForLostDevice(asset, { cost: replacementCost, note: lostNote });
+                note = (lostNote ? lostNote + " " : "") +
+                  `Billed family $${replacementCost} for replacement` +
+                  (ticket.Number ? ` (Ticket #${ticket.Number}).` : ".");
+                billedCount++;
+              } catch (e) {
+                billingErrors.push(`${tag}: ${e.message}`);
+              }
+            }
+          }
+          await signoutAsset(null, null, asset, note, "Lost", false);
+          await updateAsset(asset._id, { Status: "Lost" });
+          // Optimistic UI: find this asset's serial and mark it
+          const dr = displayRows.find((d) => d.machine?.asset === asset);
+          if (dr?.machine?.serial) {
+            localLostSerials.add(dr.machine.serial);
+            localLostSerials = localLostSerials;
+          }
+          completed++;
+          lostProgress = { completed, total };
+        }),
+      );
+      if (billingErrors.length) {
+        updateLostError = `Marked as lost, but some invoices could not be sent — ${billingErrors.join("; ")}`;
+        if (billedCount) showToast(`Queued ${billedCount} invoice(s)`, "info");
+      } else {
+        showToast(
+          billForReplacement
+            ? `Marked ${total} device(s) lost and queued ${billedCount} invoice(s)`
+            : `Marked ${total} device(s) lost`,
+          "success",
+        );
+        closeLostConfirm();
+      }
+    } catch (e) {
+      updateLostError = e instanceof Error ? e.message : "Failed to update status.";
+    } finally {
+      isUpdatingLostStatus = false;
+    }
+  }
+
+  function openBulkMessageSender() {
+    if (!mountBulkMessageSender) mountBulkMessageSender = true;
+    showBulkMessageSender = true;
+  }
+
   async function confirmBatchDeviceAction() {
     batchActionInProgress = true;
     showBatchActionConfirm = false;
@@ -97,6 +203,9 @@
     const succeeded: string[] = [];
     const failed: { serial: string; error: string }[] = [];
     const disabling = pendingBatchAction === "disable";
+    const total = serials.length;
+    let completed = 0;
+    batchActionProgress = { completed: 0, total };
     try {
       await Promise.all(
         serials.map(async (serial) => {
@@ -104,6 +213,8 @@
           const asset = dr?.machine?.asset;
           if (!asset) {
             failed.push({ serial, error: "Asset not found" });
+            completed++;
+            batchActionProgress = { completed, total };
             return;
           }
           try {
@@ -120,13 +231,19 @@
           } catch (err) {
             failed.push({ serial, error: err instanceof Error ? err.message : "Unknown error" });
           }
+          completed++;
+          batchActionProgress = { completed, total };
         })
       );
     } finally {
       batchActionInProgress = false;
       batchActionResults = { succeeded, failed, action: pendingBatchAction };
       if (failed.length === 0) {
-        selectedSerials = new Set();
+        showToast(
+          `${disabling ? "Disabled" : "Re-enabled"} ${succeeded.length} device(s)`,
+          "success"
+        );
+        // Selection kept so user can chain actions (e.g. mark lost then disable)
       }
     }
   }
@@ -863,20 +980,28 @@
       <b>{exportRows.filter((row) => row.Serial).length}</b> last-used machines
     </p>
 
-    <!-- Batch action bar (IT only) -->
-    {#if isIt && selectedSerials.size > 0}
+    <!-- Batch action bar -->
+    {#if selectedSerials.size > 0}
       <div class="batch-action-bar w3-bar">
         <span class="w3-bar-item"><b>{selectedSerials.size}</b> device(s) selected</span>
-        <button
-          class="w3-button w3-red w3-bar-item"
-          disabled={batchActionInProgress}
-          on:click={() => openBatchAction("disable")}
-        >Disable Selected</button>
-        <button
-          class="w3-button w3-green w3-bar-item"
-          disabled={batchActionInProgress}
-          on:click={() => openBatchAction("reenable")}
-        >Re-enable Selected</button>
+        <button class="w3-button w3-blue w3-bar-item" on:click={openBulkMessageSender}>
+          Send Email
+        </button>
+        <button class="w3-button w3-orange w3-bar-item" disabled={isUpdatingLostStatus} on:click={openLostConfirm}>
+          Mark as Lost
+        </button>
+        {#if isIt}
+          <button
+            class="w3-button w3-red w3-bar-item"
+            disabled={batchActionInProgress}
+            on:click={() => openBatchAction("disable")}
+          >Disable Selected</button>
+          <button
+            class="w3-button w3-green w3-bar-item"
+            disabled={batchActionInProgress}
+            on:click={() => openBatchAction("reenable")}
+          >Re-enable Selected</button>
+        {/if}
         <button
           class="w3-button w3-light-grey w3-bar-item"
           on:click={() => (selectedSerials = new Set())}
@@ -884,10 +1009,17 @@
       </div>
     {/if}
 
+    <!-- Batch device action in-progress indicator -->
+    {#if batchActionInProgress}
+      <div class="w3-container w3-pale-blue w3-border w3-margin-bottom">
+        <p>{pendingBatchAction === "disable" ? "Disabling" : "Re-enabling"} devices… {batchActionProgress.completed}/{batchActionProgress.total} done</p>
+      </div>
+    {/if}
+
     <!-- Batch action confirm dialog -->
     {#if showBatchActionConfirm}
-      <div class="modal-wrap">
-        <div class="modal-content w3-card w3-padding">
+      <div class="modal-wrap" style="display:flex;align-items:center;justify-content:center;z-index:2000;">
+        <div class="modal-content w3-card" style="max-width:440px;width:90vw;padding:2em;position:relative;">
           <h4>{pendingBatchAction === "disable" ? "Disable" : "Re-enable"} {selectedSerials.size} device(s)?</h4>
           {#if pendingBatchAction === "disable"}
             <p class="w3-small">Disabled devices will show a lock screen and cannot be used until re-enabled.</p>
@@ -901,6 +1033,82 @@
             >Confirm {pendingBatchAction === "disable" ? "Disable" : "Re-enable"}</button>
             <button class="w3-button w3-light-grey" on:click={() => (showBatchActionConfirm = false)}>Cancel</button>
           </div>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Lost device confirm dialog -->
+    {#if showLostConfirm}
+      <div class="modal-wrap" style="display:flex;align-items:center;justify-content:center;z-index:2000;">
+        <div class="modal-content w3-card" style="max-width:440px;width:90vw;padding:2em;position:relative;">
+          <button class="close-modal-btn" on:click={closeLostConfirm} disabled={isUpdatingLostStatus} aria-label="Close" type="button">&times;</button>
+          <h3>Mark {selectedSerials.size} device(s) as Lost?</h3>
+          <label for="sdr-lost-note">Optional Note:</label>
+          <textarea
+            id="sdr-lost-note"
+            class="w3-input w3-border"
+            rows="3"
+            bind:value={lostNote}
+            placeholder="Add a note (optional)"
+          ></textarea>
+          <div class="w3-margin-top">
+            <label>
+              <input type="checkbox" class="w3-check" bind:checked={billForReplacement} disabled={isUpdatingLostStatus} />
+              Bill family for replacement
+            </label>
+            {#if billForReplacement}
+              <div class="w3-margin-top">
+                <label for="sdr-replacement-cost">Replacement cost ($):</label>
+                <input
+                  id="sdr-replacement-cost"
+                  type="number"
+                  min="0"
+                  class="w3-input w3-border"
+                  bind:value={replacementCost}
+                  disabled={isUpdatingLostStatus}
+                />
+              </div>
+              <p class="w3-small w3-text-gray">
+                {billableSelectedCount} of {selectedSerials.size} selected device(s) have a current student and can be billed.
+              </p>
+            {/if}
+          </div>
+          <div class="w3-bar w3-margin-top">
+            <button
+              class="w3-button w3-orange w3-bar-item"
+              on:click={confirmMarkSelectedAsLost}
+              disabled={isUpdatingLostStatus || (billForReplacement && (!replacementCost || replacementCost <= 0))}
+            >
+              {isUpdatingLostStatus
+                ? billForReplacement
+                  ? `Marking & invoicing… (${lostProgress.completed}/${lostProgress.total})`
+                  : `Marking Lost… (${lostProgress.completed}/${lostProgress.total})`
+                : billForReplacement
+                  ? "Confirm & Send Invoice(s)"
+                  : "Confirm"}
+            </button>
+          </div>
+          {#if updateLostError}
+            <div class="w3-text-red">{updateLostError}</div>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    <!-- Bulk message sender -->
+    {#if mountBulkMessageSender}
+      <div
+        class="modal-wrap modal-bulk-message"
+        style:display={showBulkMessageSender ? "flex" : "none"}
+        style="align-items:center;justify-content:center;z-index:2000;"
+      >
+        <div class="modal-content" style="width:100vw;height:100vh;max-width:100vw;max-height:100vh;position:relative;">
+          <button
+            class="close-modal-btn"
+            on:click={() => (showBulkMessageSender = false)}
+            aria-label="Close"
+            type="button">&times;</button>
+          <BulkMessageSender assetTags={selectedAssetTagsForEmail} />
         </div>
       </div>
     {/if}
@@ -970,14 +1178,14 @@
         >
           <thead>
             <tr>
-              {#if isIt}<th class="select-col">
+              <th class="select-col">
                 <input
                   type="checkbox"
                   checked={selectableMachines.length > 0 && selectedSerials.size === selectableMachines.length}
                   indeterminate={selectedSerials.size > 0 && selectedSerials.size < selectableMachines.length}
                   on:change={toggleSelectAll}
                 />
-              </th>{/if}
+              </th>
               <th on:click={() => setSort("student")}>Student</th>
               <th on:click={() => setSort("status")}>Status</th>
               <th>Machine</th>
@@ -992,7 +1200,7 @@
           <tbody>
             {#each displayRows as displayRow (displayRow.key)}
               <tr class:has-warning={isWarningMachine(displayRow.machine)}>
-                {#if isIt}<td class="select-col">
+                <td class="select-col">
                   {#if displayRow.machine && displayRow.machine.serial && displayRow.machine.asset}
                     <input
                       type="checkbox"
@@ -1000,7 +1208,7 @@
                       on:change={() => toggleSelectMachine(displayRow.machine.serial)}
                     />
                   {/if}
-                </td>{/if}
+                </td>
                 <td>
                   <b><EmailDisplay email={displayRow.row.student.Email} /></b>
                   <div class="w3-small">{displayRow.row.student.Name}</div>
@@ -1045,6 +1253,9 @@
                             s/n {displayRow.machine.serial}
                           </div>
                         </div>
+                      {/if}
+                      {#if displayRow.machine.serial && localLostSerials.has(displayRow.machine.serial)}
+                        <span class="w3-tag w3-orange" style="font-size:10px;padding:1px 5px;">Marked Lost</span>
                       {/if}
                     </div>
                   {:else}
@@ -1123,7 +1334,7 @@
               </tr>
               {#if expandedMachines[displayRow.key] && displayRow.machine}
                 <tr class="expanded-row">
-                  <td colspan={isIt ? 10 : 8}>
+                  <td colspan={isIt ? 10 : 9}>
                     <div class="expanded-grid">
                       <div>
                         <h4>Recent Users</h4>
@@ -1382,7 +1593,7 @@
   .modal-wrap {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.4);
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1390,7 +1601,22 @@
   }
   .modal-content {
     background: white;
-    max-width: 480px;
-    width: 90%;
+    overflow: auto;
+  }
+  .close-modal-btn {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    background: none;
+    border: none;
+    font-size: 2em;
+    color: #888;
+    cursor: pointer;
+    z-index: 10;
+    padding: 0;
+    line-height: 1;
+  }
+  .close-modal-btn:hover {
+    color: #c6093b;
   }
 </style>


### PR DESCRIPTION
## Summary

Adds the ability to disable and re-enable Chromebooks through the Google Admin Directory API, surfaced in two places:

- **Asset inventory view** (look up a device → Google Admin Info tab): shows a prominent red/purple banner when a device is DISABLED or DEPROVISIONED, plus a Disable/Re-enable button with inline error handling and a fallback link to the Admin console
- **Reports view**: "Disable Selected" and "Re-enable Selected" batch action buttons alongside the existing "Mark as Lost" button, with a confirmation dialog and a per-device results panel that lists any failures with serials and a direct link to the Admin console

Backed by a new `mode=action` endpoint in the GAS shim (separate commit) and a `setDeviceDisabled(asset, disabled)` function in `google.ts`.

## Test plan

- [ ] Look up a known ACTIVE device → Google Admin Info tab → click "Disable Device" → confirm it shows as DISABLED in Admin console
- [ ] Look up a DISABLED device → tab shows red banner + "Re-enable Device" button → click → confirm re-enabled
- [ ] Look up a DEPROVISIONED device → shows purple banner, no action button
- [ ] Reports view: select multiple devices → "Disable Selected" → confirm dialog → devices disabled
- [ ] Reports view: "Re-enable Selected" on disabled devices → re-enabled
- [ ] Simulate a failure (bad serial) → failure row shows in results with Admin console link

🤖 Generated with [Claude Code](https://claude.com/claude-code)