### PR TITLE
Security: backend auth gating on all Netlify functions

### DIFF
--- a/src/data/contacts.ts
+++ b/src/data/contacts.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 //import type { Writable } from "svelte/store";
@@ -33,7 +34,7 @@ export function getEmails(contact: Contact) {
 export async function getContacts() {
   let params: { [key: string]: string } = { mode: "contact" };
   let paramString = new URLSearchParams(params);
-  let response = await fetch("/.netlify/functions/index?" + paramString);
+  let response = await authedFetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   logger.logVerbose("Got contact data:", json);
   contactStore.update(($contactStore) => {

--- a/src/data/contracts.ts
+++ b/src/data/contracts.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 import type { Student } from "./students";
@@ -67,7 +68,7 @@ export async function getContracts(
     params.all = "true";
   }
   let paramString = new URLSearchParams(params);
-  let response = await fetch("/.netlify/functions/index?" + paramString);
+  let response = await authedFetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   logger.logVerbose("Got asset data:", json);
   contractStore.update(($contractStore) => {
@@ -93,7 +94,7 @@ export async function mapContract(contract: Contract, student: Student) {
     id: contract._id,
     fields: { Student: [student._id], "Contract Signed": true },
   };
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?" + new URLSearchParams(params),
     {
       method: "PATCH",

--- a/src/data/google.ts
+++ b/src/data/google.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 import type { Asset } from "./inventory";
@@ -64,7 +65,7 @@ export async function getDeviceInfo(
   if (serialCache[device.Serial]) {
     return serialCache[device.Serial];
   }
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?mode=google&serial=" +
       encodeURIComponent(device.Serial)
   );
@@ -85,7 +86,7 @@ export async function getDevicesForUser(
   if (userCache[user.Email]) {
     return userCache[user.Email];
   }
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?mode=google&user=" +
       encodeURIComponent(user.Email)
   );

--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 import { Staff } from "./staff";
@@ -88,7 +89,7 @@ export async function searchForAsset(
     params.purpose = purpose;
   }
   let paramString = new URLSearchParams(params);
-  let response = await fetch("/.netlify/functions/index?" + paramString);
+  let response = await authedFetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   logger.logVerbose("Got asset data:", json);
   assetStore.update(($assetStore) => {
@@ -174,7 +175,7 @@ export async function fetchReport({
   }
 
   let paramString = new URLSearchParams(params);
-  let response = await fetch("/.netlify/functions/index?" + paramString);
+  let response = await authedFetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   logger.logVerbose("Got report data:", json);
 
@@ -224,7 +225,7 @@ export async function getAllChromebooks() {
 // Update asset function
 export async function updateAsset(id: string, fields: any) {
   try {
-    const response = await fetch("/.netlify/functions/index?mode=asset", {
+    const response = await authedFetch("/.netlify/functions/index?mode=asset", {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",

--- a/src/data/invoices.ts
+++ b/src/data/invoices.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { get } from "svelte/store";
 import { user } from "./user";
 
@@ -60,7 +61,7 @@ export async function createInvoices(
 
   const params = { mode: "invoices" };
   await get(user); // ensure session
-  const response = await fetch(
+  const response = await authedFetch(
     "/.netlify/functions/index?" + new URLSearchParams(params),
     {
       method: "POST",
@@ -85,7 +86,7 @@ export async function updateInvoices(
   }
 
   const params = { mode: "invoices" };
-  const response = await fetch(
+  const response = await authedFetch(
     "/.netlify/functions/index?" + new URLSearchParams(params),
     { method: "PATCH", body: JSON.stringify(updates) }
   );
@@ -101,7 +102,7 @@ export async function getInvoices(
   } = {}
 ): Promise<InvoiceResult[]> {
   const qs = new URLSearchParams({ mode: "invoices", ...params } as any);
-  const response = await fetch("/.netlify/functions/index?" + qs, {
+  const response = await authedFetch("/.netlify/functions/index?" + qs, {
     method: "GET",
   });
   const json = await response.json();

--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 
@@ -13,7 +14,7 @@ export async function getMessages() {
   let params: { [key: string]: string } = { mode: "message" };
 
   let paramString = new URLSearchParams(params);
-  let response = await fetch("/.netlify/functions/index?" + paramString);
+  let response = await authedFetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   logger.logVerbose("Got message data:", json);
   messagesStore.update(($messageStore) => {

--- a/src/data/notifications.ts
+++ b/src/data/notifications.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { get } from "svelte/store";
 import { user } from "./user";
 import { logger } from "@utils/log";
@@ -84,7 +85,7 @@ export async function updateNotifications(
   }
 
   let params = { mode: "notifications" };
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?" + new URLSearchParams(params),
     {
       method: "PATCH",
@@ -99,7 +100,7 @@ export async function getNotifications(
   params: { ticketNumber?: string } = {}
 ): Promise<NotificationResult[]> {
   let qs = new URLSearchParams({ mode: "notifications", ...params } as any);
-  let response = await fetch("/.netlify/functions/index?" + qs, {
+  let response = await authedFetch("/.netlify/functions/index?" + qs, {
     method: "GET",
   });
   let json = await response.json();
@@ -143,7 +144,7 @@ export async function createNotifications(
     "Firing off request to create notifications",
     notifications
   );
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?" + new URLSearchParams(params),
     {
       method: "POST",

--- a/src/data/signout.ts
+++ b/src/data/signout.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import type { Student } from "./students";
 import type { Staff } from "./staff";
 import type { Asset } from "./inventory";
@@ -46,7 +47,7 @@ export async function signoutAsset(
     params.staffRecordId = staff._id;
   }
   params.FormUser = $user.email;
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?" +
       new URLSearchParams(params as Record<string, string>)
   );

--- a/src/data/signoutHistory.ts
+++ b/src/data/signoutHistory.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import type { Asset } from "./inventory";
 import type { Student } from "./students";
 import { writable } from "svelte/store";
@@ -59,7 +60,7 @@ export async function lookupSignoutHistory({
     params.staffId = staff._id;
   }
   let paramString = new URLSearchParams(params);
-  let response = await fetch("/.netlify/functions/index?" + paramString);
+  let response = await authedFetch("/.netlify/functions/index?" + paramString);
   let json = await response.json();
   return json.map((item) => ({ ...item.fields, _id: item.id }));
 }

--- a/src/data/sisData.ts
+++ b/src/data/sisData.ts
@@ -1,10 +1,11 @@
+import { authedFetch } from "@utils/authedFetch";
 // Simple SIS API testing functions
 import { logger } from "@utils/log";
 export async function testSISConnection() {
   logger.logVerbose("[SIS Data] Testing basic connectivity...");
 
   try {
-    const response = await fetch(
+    const response = await authedFetch(
       "/.netlify/functions/index?mode=sisApi&testStep=connect"
     );
     return await response.json();
@@ -18,7 +19,7 @@ export async function testSISAuth() {
   logger.logVerbose("[SIS Data] Testing SIS authentication...");
 
   try {
-    const response = await fetch(
+    const response = await authedFetch(
       "/.netlify/functions/index?mode=sisApi&testStep=auth"
     );
     return await response.json();
@@ -32,7 +33,7 @@ export async function testStudentLookup(studentEmail: string) {
   logger.logVerbose("[SIS Data] Testing student lookup for:", studentEmail);
 
   try {
-    const response = await fetch(
+    const response = await authedFetch(
       `/.netlify/functions/index?mode=sisApi&testStep=student&studentEmail=${encodeURIComponent(
         studentEmail
       )}`
@@ -48,7 +49,7 @@ export async function testScheduleLookup(studentEmail: string) {
   logger.logVerbose("[SIS Data] Testing schedule lookup for:", studentEmail);
 
   try {
-    const response = await fetch(
+    const response = await authedFetch(
       `/.netlify/functions/index?mode=sisApi&testStep=schedule&studentEmail=${encodeURIComponent(
         studentEmail
       )}`

--- a/src/data/staff.ts
+++ b/src/data/staff.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 
@@ -20,7 +21,7 @@ export async function searchForStaff(name) {
   if (searchCache[name]) {
     return searchCache[name];
   } else {
-    let response = await fetch(
+    let response = await authedFetch(
       "/.netlify/functions/index?mode=staff&name=" + encodeURIComponent(name)
     );
     let json = await response.json();

--- a/src/data/students.ts
+++ b/src/data/students.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 
@@ -21,7 +22,7 @@ export async function searchForStudent(name) {
   if (cachedSearch[name]) {
     return cachedSearch[name];
   }
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?mode=student&name=" + encodeURIComponent(name)
   );
   let json = await response.json();
@@ -60,7 +61,7 @@ export async function fetchStudentsForReport({
     params.emails = emails.join(",");
   }
 
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?" + new URLSearchParams(params)
   );
   if (!response.ok) {
@@ -106,7 +107,7 @@ export function getStudent(name: string): Student {
 }
 
 export async function addStudentNote(student: Student, note: string) {
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index?mode=updateStudent&studentId=" +
       student._id +
       "&note=" +

--- a/src/data/tickets.ts
+++ b/src/data/tickets.ts
@@ -1,3 +1,4 @@
+import { authedFetch } from "@utils/authedFetch";
 import { writable, get } from "svelte/store";
 import { logger } from "@utils/log";
 import { restructureLookupFields } from "./restructureLookups";
@@ -104,7 +105,7 @@ export async function getTickets(
     return cachedQueries[cacheKey];
   }
 
-  let response = await fetch(
+  let response = await authedFetch(
     "/.netlify/functions/index" +
       (queryString ? "?mode=tickets&" + queryString : "?mode=tickets")
   );
@@ -157,7 +158,7 @@ export function getTicket(id: string): Ticket {
 }
 
 export async function createTicket(ticketData: Partial<Ticket>) {
-  let response = await fetch("/.netlify/functions/index?mode=tickets", {
+  let response = await authedFetch("/.netlify/functions/index?mode=tickets", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -184,7 +185,7 @@ export async function createTicket(ticketData: Partial<Ticket>) {
 }
 
 export async function updateTicket(id: string, updates: Partial<Ticket>) {
-  let response = await fetch("/.netlify/functions/index?mode=tickets", {
+  let response = await authedFetch("/.netlify/functions/index?mode=tickets", {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",

--- a/src/functions/auth.ts
+++ b/src/functions/auth.ts
@@ -1,0 +1,37 @@
+import type { Context } from "aws-lambda";
+
+const IT_USERS = new Set([
+  "thinkle@innovationcharter.org",
+  "ntroy@innovationcharter.org",
+  "aspence@innovationcharter.org",
+]);
+
+export type AuthLevel = "none" | "teacher" | "it";
+
+// Netlify sets CONTEXT="production" in prod; undefined in local dev via `netlify dev`.
+// Trust local dev so the Identity widget bypass in user.ts doesn't break the dev loop.
+const IS_PRODUCTION = process.env.CONTEXT === "production";
+
+export function getAuthLevel(context: Context): AuthLevel {
+  if (!IS_PRODUCTION) return "it";
+
+  const email: string | undefined = (context as any).clientContext?.user?.email;
+  if (!email) return "none";
+
+  const at = email.indexOf("@");
+  if (at < 0) return "none";
+  const local = email.slice(0, at);
+  const domain = email.slice(at + 1);
+
+  if (domain !== "innovationcharter.org") return "none";
+  if (local.includes(".")) return "none"; // student account (john.smith@...)
+  if (IT_USERS.has(email)) return "it";
+  return "teacher";
+}
+
+export function forbidden(detail?: string) {
+  return {
+    statusCode: 403,
+    body: JSON.stringify({ error: "Forbidden", detail: detail ?? "Insufficient permissions" }),
+  };
+}

--- a/src/functions/auth.ts
+++ b/src/functions/auth.ts
@@ -8,12 +8,14 @@ const IT_USERS = new Set([
 
 export type AuthLevel = "none" | "teacher" | "it";
 
-// Netlify sets CONTEXT="production" in prod; undefined in local dev via `netlify dev`.
-// Trust local dev so the Identity widget bypass in user.ts doesn't break the dev loop.
-const IS_PRODUCTION = process.env.CONTEXT === "production";
+// Netlify sets CONTEXT to "production", "deploy-preview", or "branch-deploy" in hosted
+// environments, and leaves it undefined when running locally via `netlify dev`.
+// Only skip auth when CONTEXT is truly absent (local dev) — previews/branch deploys
+// should still enforce auth.
+const IS_LOCAL_DEV = !process.env.CONTEXT;
 
 export function getAuthLevel(context: Context): AuthLevel {
-  if (!IS_PRODUCTION) return "it";
+  if (IS_LOCAL_DEV) return "it";
 
   const email: string | undefined = (context as any).clientContext?.user?.email;
   if (!email) return "none";

--- a/src/functions/googleAdmin.ts
+++ b/src/functions/googleAdmin.ts
@@ -1,11 +1,16 @@
 import type { APIGatewayEvent, Context } from "aws-lambda";
+import { getAuthLevel, forbidden } from "./auth";
 const SHIM_SECRET = process.env.SHIM_SECRET;
 const SHIM_URL = process.env.SHIM_URL;
 
 export async function handler(event: APIGatewayEvent, context: Context) {
   console.log("Google Shim Handler");
   if (event.httpMethod == "GET") {
-    const { user, serial } = event.queryStringParameters;
+    const { user, serial, action } = event.queryStringParameters || {};
+    // Device actions (disable/reenable) require IT-level access
+    if (action && getAuthLevel(context) !== "it") {
+      return forbidden("IT access required for device actions");
+    }
     let params;
     if (user) {
       params = {

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,4 +1,5 @@
 import type { APIGatewayEvent, Context } from "aws-lambda";
+import { getAuthLevel, forbidden } from "./auth";
 import { handler as studentHandler } from "./students";
 import { handler as staffHandler } from "./staff";
 import { handler as inventoryHandler } from "./inventory";
@@ -35,7 +36,10 @@ export async function handler(
   event: APIGatewayEvent,
   context: Context
 ): Promise<{ statusCode: number; body: string }> {
-  if (modes[event.queryStringParameters.mode]) {
+  if (getAuthLevel(context) === "none") {
+    return forbidden("School login required");
+  }
+  if (modes[event.queryStringParameters?.mode]) {
     return modes[event.queryStringParameters.mode](event, context);
   } else {
     return {

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -39,8 +39,9 @@ export async function handler(
   if (getAuthLevel(context) === "none") {
     return forbidden("School login required");
   }
-  if (modes[event.queryStringParameters?.mode]) {
-    return modes[event.queryStringParameters.mode](event, context);
+  const mode = event.queryStringParameters?.mode;
+  if (modes[mode]) {
+    return modes[mode](event, context);
   } else {
     return {
       statusCode: 400,

--- a/src/ui/utils/authedFetch.ts
+++ b/src/ui/utils/authedFetch.ts
@@ -1,0 +1,16 @@
+import netlifyIdentity from "netlify-identity-widget";
+
+function getAuthHeaders(): Record<string, string> {
+  const token = (netlifyIdentity.currentUser() as any)?.token?.access_token;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export function authedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  return fetch(url, {
+    ...options,
+    headers: {
+      ...getAuthHeaders(),
+      ...(options.headers as Record<string, string> || {}),
+    },
+  });
+}

--- a/src/ui/utils/authedFetch.ts
+++ b/src/ui/utils/authedFetch.ts
@@ -1,16 +1,22 @@
 import netlifyIdentity from "netlify-identity-widget";
 
-function getAuthHeaders(): Record<string, string> {
-  const token = (netlifyIdentity.currentUser() as any)?.token?.access_token;
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const user = netlifyIdentity.currentUser() as any;
+  if (!user) return {};
+  // jwt() refreshes the token if it has expired, unlike reading token.access_token directly
+  const token: string = await user.jwt();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-export function authedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+export async function authedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const authHeaders = await getAuthHeaders();
+  // Normalise caller-supplied headers to a plain object so we can spread them
+  const callerHeaders: Record<string, string> =
+    options.headers instanceof Headers
+      ? Object.fromEntries((options.headers as Headers).entries())
+      : (options.headers as Record<string, string>) || {};
   return fetch(url, {
     ...options,
-    headers: {
-      ...getAuthHeaders(),
-      ...(options.headers as Record<string, string> || {}),
-    },
+    headers: { ...authHeaders, ...callerHeaders },
   });
 }


### PR DESCRIPTION
## Summary

- All `/.netlify/functions/index` routes now require a valid Netlify Identity JWT (`Authorization: Bearer <token>`)
- Non-`@innovationcharter.org` addresses → 403
- Student accounts (`john.smith@...`, dot in local part) → 403  
- Teacher accounts (`jsmith@...`) → allowed for read/signout routes
- IT allowlist only → device disable/reenable actions

## Changes

**Backend (`src/functions/`)**
- `auth.ts` (new): `getAuthLevel(context)` reads the Netlify-decoded JWT from `context.clientContext.user`. Returns `none` / `teacher` / `it`. Bypasses auth in local dev (`CONTEXT !== 'production'`) so the localhost hardcoded-email bypass in `user.ts` doesn't block development.
- `index.ts`: blocks `"none"` auth level before routing to any handler
- `googleAdmin.ts`: additionally blocks `action=` requests unless `"it"` level

**Frontend (`src/data/`, `src/ui/utils/`)**
- `authedFetch.ts` (new): wraps `fetch()` to attach `Authorization: Bearer <token>` from `netlifyIdentity.currentUser()`
- All 13 `src/data/*.ts` files: `await fetch(` → `await authedFetch(`

## Test plan
- [ ] Log in as teacher account — signout and lookup routes work
- [ ] Log out — all API calls return 403
- [ ] Try a student account — 403
- [ ] Log in as IT user — disable/reenable works
- [ ] Log in as teacher — disable/reenable returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)